### PR TITLE
Adding contribution section on gathering troubleshooting information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,18 @@ To contribute a new language translation to Buzz:
 2. Fill in the translations in the `.po` file generated in `locale/[locale]/LC_MESSAGES`.
 3. Run `make translation_mo` to compile the translations, then test your changes.
 4. Create a new pull request with your changes.
+
+## Troubleshooting
+
+If you encounter any issues, please open an issue on the Buzz GitHub repository. Here are a few tips to gather data about the issue, so it is easier for us to fix.
+
+**Provide details**
+
+What version of the Buzz are you using? On what OS? What are steps to reproduce it? What settings were selected.
+
+**Logs**
+
+Log files contain valuable information about what the Buzz was doing before the issue occurred. You can get the logs like this:
+* Mac and Linux run the app from the terminal and check the output.
+* Windows paste this into the Windows Explorer address bar `%USERPROFILE%\AppData\Local\Buzz\Buzz\Logs` and check the logs file.
+


### PR DESCRIPTION
Some confirmation for Macs and getting log output is needed. Will Buzz print logging output if tun from command line? Or is there some place where it stores logs on Macs? 