### PR TITLE
Will download HF models to Buzz cache folder

### DIFF
--- a/buzz/model_loader.py
+++ b/buzz/model_loader.py
@@ -232,7 +232,7 @@ class HuggingfaceDownloadMonitor:
         logging.debug(f"=============== model_root: {model_root}")
 
         normalized_model_root = os.path.normpath(model_root)
-        normalized_hub_path = os.path.normpath("Buzz/models/")
+        normalized_hub_path = os.path.normpath("/models/")
         index = normalized_model_root.find(normalized_hub_path)
         if index == -1:
             raise ValueError(f"Invalid model_root, '{normalized_hub_path}' not found")

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -6,8 +6,7 @@ sidebar_position: 5
 1. **Where are the models stored?**
 
    The Whisper models are stored in `~/.cache/whisper`. The Whisper.cpp models are stored in `~/Library/Caches/Buzz`
-   (Mac OS), `~/.cache/Buzz` (Unix), or `C:\Users\<username>\AppData\Local\Buzz\Buzz\Cache` (Windows). The Hugging Face
-   models are stored in `~/.cache/huggingface/hub`.
+   (Mac OS), `~/.cache/Buzz` (Unix), or `C:\Users\<username>\AppData\Local\Buzz\Buzz\Cache` (Windows).
 
 2. **What can I try if the transcription runs too slowly?**
 


### PR DESCRIPTION
This change will bring the following improvements:
- Download progress will work from snaps (hopefully) as otherwise app from snap can't access the HF hub default location
- Will let us clean up on uninstall