### PR TITLE
Will not run app during the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ benchmarks: buzz/whisper_cpp.py translation_mo
 
 dist/Buzz dist/Buzz.app: buzz/whisper_cpp.py translation_mo
 	pyinstaller --noconfirm Buzz.spec
-	./dist/Buzz/Buzz --version
 
 version:
 	poetry version ${version}


### PR DESCRIPTION
This should prevent Windows builds from hanging. App testing still performed by the test set.