### PR TITLE
fix: correct pip install command option typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To have GPU support for Nvidia GPUS on Windows, for PyPI installed version ensur
 
 ```
 pip3 uninstall torch torchaudio
-pip3 install torch==2.2.2+cu121 torchaudio==2.2.2+cu121 nvidia-cublas-cu12==12.1.3.1 nvidia-cuda-cupti-cu12==12.1.105 nvidia-cuda-nvrtc-cu12==12.1.105 nvidia-cuda-runtime-cu12==12.1.105 nvidia-cufft-cu12==11.0.2.54 nvidia-curand-cu12==10.3.2.106 nvidia-cusolver-cu12==11.4.5.107 nvidia-cusparse-cu12==12.1.0.106 nvidia-nccl-cu12==2.19.3 nvidia-nvtx-cu12==12.1.105  --extea-index-url https://download.pytorch.org/whl/cu121 --extea-index-url https://pypi.ngc.nvidia.com
+pip3 install torch==2.2.2+cu121 torchaudio==2.2.2+cu121 nvidia-cublas-cu12==12.1.3.1 nvidia-cuda-cupti-cu12==12.1.105 nvidia-cuda-nvrtc-cu12==12.1.105 nvidia-cuda-runtime-cu12==12.1.105 nvidia-cufft-cu12==11.0.2.54 nvidia-curand-cu12==10.3.2.106 nvidia-cusolver-cu12==11.4.5.107 nvidia-cusparse-cu12==12.1.0.106 nvidia-nccl-cu12==2.19.3 nvidia-nvtx-cu12==12.1.105  --extra-index-url https://download.pytorch.org/whl/cu121 --extra-index-url https://pypi.ngc.nvidia.com
 ```
 
 ### Linux


### PR DESCRIPTION
Replaced incorrect '--extea-index-url' option with the correct '--extra-index-url' in the pip install command to resolve the "no such option" error.