### PR TITLE
Add Linux AppImage packaging and offline deployment support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
           - os: macos-15-intel
           - os: macos-latest
           - os: windows-latest
+          - os: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -247,6 +248,10 @@ jobs:
             cp -r ./dll_backup ./buzz/
             uv run make bundle_windows
 
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+
+            uv run make bundle_appimage
+
           fi
         env:
           BUZZ_CODESIGN_IDENTITY: ${{ secrets.BUZZ_CODESIGN_IDENTITY }}
@@ -266,6 +271,7 @@ jobs:
             dist/Buzz*-windows.exe
             dist/Buzz*-windows-*.bin
             dist/Buzz*-mac.dmg
+            dist/Buzz*.AppImage
 
   build_wheels:
     runs-on: ${{ matrix.os }}
@@ -339,6 +345,7 @@ jobs:
           - os: macos-15-intel
           - os: macos-latest
           - os: windows-latest
+          - os: ubuntu-latest
     needs: [build, test]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -365,6 +372,7 @@ jobs:
             Buzz*.exe
             Buzz*.bin
             Buzz*.dmg
+            Buzz*.AppImage
 
 #  Brew Cask deployment fails and the app is deprecated on Brew.
 #  deploy_brew_cask:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ bundle_mac: dist/Buzz.app codesign_all_mac zip_mac notarize_zip staple_app_mac d
 
 bundle_mac_unsigned: dist/Buzz.app zip_mac dmg_mac_unsigned
 
+bundle_appimage: dist/Buzz
+	./appimage/build-appimage.sh
+
 clean:
 ifeq ($(OS), Windows_NT)
 	-rmdir /s /q buzz\whisper_cpp
@@ -236,6 +239,9 @@ else
 		python3 msgfmt.py -o $$dir/LC_MESSAGES/buzz.mo $$dir/LC_MESSAGES/buzz.po; \
 	done
 endif
+
+download-models:
+	uv run python scripts/download-models.py
 
 lint:
 	ruff check . --fix

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build Buzz as a Linux AppImage.
+#
+# Prerequisites — install before running:
+#   Ubuntu/Debian:
+#     sudo apt install ffmpeg libportaudio2 libpulse0 libvulkan-dev ccache cmake \
+#       libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+#       libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-shape0 \
+#       libxcb-cursor0 libgl1-mesa-dev gettext
+#   RHEL/AlmaLinux 9:
+#     sudo dnf install epel-release
+#     sudo dnf install ffmpeg-free portaudio pulseaudio-libs-devel vulkan-loader-devel \
+#       ccache cmake libxkbcommon-x11 libxcb mesa-libGL-devel gettext
+#
+#   Both: uv, Vulkan SDK (https://vulkan.lunarg.com/sdk/home)
+#
+# Usage:
+#   ./appimage/build-appimage.sh          # standalone
+#   uv run make bundle_appimage           # via Makefile
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$PROJECT_DIR/build/appimage"
+APPDIR="$BUILD_DIR/Buzz.AppDir"
+ARCH="$(uname -m)"
+VERSION="$(grep '^version := ' "$PROJECT_DIR/Makefile" | head -1 | awk '{print $3}')"
+OUTPUT="$PROJECT_DIR/dist/Buzz-${VERSION}-${ARCH}.AppImage"
+
+echo "==> Building Buzz ${VERSION} AppImage for ${ARCH}"
+
+# ── Step 1: PyInstaller bundle ──────────────────────────────────────────────
+# Reuses the existing Buzz.spec (same as macOS/Windows builds).
+# Produces dist/Buzz/ with the self-contained application.
+if [ ! -d "$PROJECT_DIR/dist/Buzz" ]; then
+    echo "==> Running PyInstaller..."
+    cd "$PROJECT_DIR"
+    uv run make dist/Buzz
+fi
+
+# ── Step 2: Create AppDir ───────────────────────────────────────────────────
+echo "==> Assembling AppDir..."
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" \
+         "$APPDIR/usr/share/applications" \
+         "$APPDIR/usr/share/icons/hicolor/scalable/apps" \
+         "$APPDIR/usr/share/metainfo"
+
+# Copy entire PyInstaller output into usr/bin/
+cp -a "$PROJECT_DIR/dist/Buzz/." "$APPDIR/usr/bin/"
+
+# ── Step 3: Desktop integration ─────────────────────────────────────────────
+# Desktop file — Exec must be just the binary name for AppImage spec
+cat > "$APPDIR/io.github.chidiwilliams.Buzz.desktop" << 'EOF'
+[Desktop Entry]
+Type=Application
+Name=Buzz
+GenericName=Audio Transcriber
+Comment=Transcribe and translate audio offline
+Exec=Buzz
+Icon=io.github.chidiwilliams.Buzz
+Terminal=false
+Categories=AudioVideo;Audio;
+MimeType=audio/mpeg;audio/wav;audio/ogg;audio/flac;video/mp4;video/webm;
+EOF
+cp "$APPDIR/io.github.chidiwilliams.Buzz.desktop" "$APPDIR/usr/share/applications/"
+
+# Icon (SVG at AppDir root + XDG hicolor location)
+cp "$PROJECT_DIR/share/icons/io.github.chidiwilliams.Buzz.svg" "$APPDIR/"
+cp "$PROJECT_DIR/share/icons/io.github.chidiwilliams.Buzz.svg" \
+   "$APPDIR/usr/share/icons/hicolor/scalable/apps/"
+
+# AppStream metainfo (appimagetool expects .appdata.xml suffix)
+cp "$PROJECT_DIR/share/metainfo/io.github.chidiwilliams.Buzz.metainfo.xml" \
+   "$APPDIR/usr/share/metainfo/io.github.chidiwilliams.Buzz.appdata.xml"
+
+# ── Step 4: AppRun entry point ──────────────────────────────────────────────
+cat > "$APPDIR/AppRun" << 'APPRUN'
+#!/bin/bash
+SELF="$(readlink -f "$0")"
+APPDIR="$(dirname "$SELF")"
+
+export PATH="$APPDIR/usr/bin:$PATH"
+export LD_LIBRARY_PATH="$APPDIR/usr/bin:${LD_LIBRARY_PATH:-}"
+export QT_MEDIA_BACKEND=ffmpeg
+export PULSE_LATENCY_MSEC=30
+
+exec "$APPDIR/usr/bin/Buzz" "$@"
+APPRUN
+chmod +x "$APPDIR/AppRun"
+
+# ── Step 5: Build AppImage ──────────────────────────────────────────────────
+echo "==> Packaging AppImage..."
+mkdir -p "$BUILD_DIR" "$PROJECT_DIR/dist"
+
+APPIMAGETOOL="$BUILD_DIR/appimagetool-${ARCH}"
+if [ ! -x "$APPIMAGETOOL" ]; then
+    echo "==> Downloading appimagetool..."
+    curl -fSL -o "$APPIMAGETOOL" \
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+    chmod +x "$APPIMAGETOOL"
+fi
+
+# Download AppImage runtime (appimagetool's built-in download can fail)
+RUNTIME="$BUILD_DIR/runtime-${ARCH}"
+if [ ! -f "$RUNTIME" ]; then
+    echo "==> Downloading AppImage runtime..."
+    curl -fSL -o "$RUNTIME" \
+        "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-${ARCH}"
+fi
+
+# Use --appimage-extract-and-run when FUSE is unavailable (CI, containers)
+EXTRA_ARGS=(--runtime-file "$RUNTIME")
+if [ "${CI:-}" = "true" ] || ! command -v fusermount &>/dev/null; then
+    EXTRA_ARGS+=(--appimage-extract-and-run)
+fi
+
+ARCH="$ARCH" "$APPIMAGETOOL" "${EXTRA_ARGS[@]}" "$APPDIR" "$OUTPUT"
+
+echo "==> Done: $OUTPUT"

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -74,6 +74,7 @@ cp "$PROJECT_DIR/share/icons/io.github.chidiwilliams.Buzz.svg" \
 # AppStream metainfo (appimagetool expects .appdata.xml suffix)
 cp "$PROJECT_DIR/share/metainfo/io.github.chidiwilliams.Buzz.metainfo.xml" \
    "$APPDIR/usr/share/metainfo/io.github.chidiwilliams.Buzz.appdata.xml"
+APPSTREAM_FILE="$APPDIR/usr/share/metainfo/io.github.chidiwilliams.Buzz.appdata.xml"
 
 # ── Step 4: AppRun entry point ──────────────────────────────────────────────
 cat > "$APPDIR/AppRun" << 'APPRUN'
@@ -111,9 +112,23 @@ if [ ! -f "$RUNTIME" ]; then
 fi
 
 # Use --appimage-extract-and-run when FUSE is unavailable (CI, containers)
-EXTRA_ARGS=(--runtime-file "$RUNTIME")
+EXTRA_ARGS=(--runtime-file "$RUNTIME" --no-appstream)
 if [ "${CI:-}" = "true" ] || ! command -v fusermount &>/dev/null; then
     EXTRA_ARGS+=(--appimage-extract-and-run)
+fi
+
+# Validate AppStream metadata ourselves in offline mode. appimagetool's internal
+# appstream-util invocation performs network checks for remote screenshots,
+# which breaks in proxied or restricted build environments even when the
+# metadata itself is otherwise valid.
+if command -v appstreamcli >/dev/null 2>&1; then
+    echo "==> Validating AppStream metadata with appstreamcli (--no-net)..."
+    appstreamcli validate --no-net "$APPSTREAM_FILE"
+fi
+
+if command -v appstream-util >/dev/null 2>&1; then
+    echo "==> Validating AppStream metadata with appstream-util (--nonet)..."
+    appstream-util validate-relax --nonet "$APPSTREAM_FILE"
 fi
 
 ARCH="$ARCH" "$APPIMAGETOOL" "${EXTRA_ARGS[@]}" "$APPDIR" "$OUTPUT"

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -111,10 +111,10 @@ if [ ! -f "$RUNTIME" ]; then
         "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-${ARCH}"
 fi
 
-# Use --appimage-extract-and-run when FUSE is unavailable (CI, containers)
+# Use APPIMAGETOOL_EXTRACT_AND_RUN when FUSE is unavailable (CI, containers)
 EXTRA_ARGS=(--runtime-file "$RUNTIME" --no-appstream)
 if [ "${CI:-}" = "true" ] || ! command -v fusermount &>/dev/null; then
-    EXTRA_ARGS+=(--appimage-extract-and-run)
+    export APPIMAGETOOL_EXTRACT_AND_RUN=1
 fi
 
 # Validate AppStream metadata ourselves in offline mode. appimagetool's internal

--- a/buzz/buzz.py
+++ b/buzz/buzz.py
@@ -13,8 +13,14 @@ import buzz.cuda_setup  # noqa: F401
 
 from platformdirs import user_log_dir, user_cache_dir, user_data_dir
 
-# Will download all Huggingface data to the app cache directory
-os.environ.setdefault("HF_HOME", user_cache_dir("Buzz"))
+# Will download all Huggingface data to the app cache directory.
+# When BUZZ_MODEL_ROOT is set, derive HF_HOME from it so that HuggingFace
+# adapter downloads (e.g. MMS language adapters) also go to the custom path.
+_model_root = os.environ.get("BUZZ_MODEL_ROOT")
+if _model_root:
+    os.environ.setdefault("HF_HOME", os.path.dirname(_model_root))
+else:
+    os.environ.setdefault("HF_HOME", user_cache_dir("Buzz"))
 
 from buzz.assets import APP_BASE_DIR
 

--- a/buzz/model_loader.py
+++ b/buzz/model_loader.py
@@ -331,10 +331,28 @@ class TranscriptionModel:
 
     @staticmethod
     def default():
-        model_type = next(
-            model_type for model_type in ModelType if model_type.is_available()
-        )
-        return TranscriptionModel(model_type=model_type)
+        default_type_env = os.getenv("BUZZ_DEFAULT_MODEL_TYPE")
+        default_size_env = os.getenv("BUZZ_DEFAULT_MODEL_SIZE")
+
+        if default_type_env:
+            try:
+                model_type = ModelType(default_type_env)
+            except ValueError:
+                logging.warning("Unknown BUZZ_DEFAULT_MODEL_TYPE=%r, using default", default_type_env)
+                model_type = next(mt for mt in ModelType if mt.is_available())
+        else:
+            model_type = next(mt for mt in ModelType if mt.is_available())
+
+        if default_size_env:
+            try:
+                model_size = WhisperModelSize(default_size_env)
+            except ValueError:
+                logging.warning("Unknown BUZZ_DEFAULT_MODEL_SIZE=%r, using default", default_size_env)
+                model_size = WhisperModelSize.TINY
+        else:
+            model_size = WhisperModelSize.TINY
+
+        return TranscriptionModel(model_type=model_type, whisper_model_size=model_size)
 
     @staticmethod
     def open_path(path: str):

--- a/buzz/transcriber/whisper_file_transcriber.py
+++ b/buzz/transcriber/whisper_file_transcriber.py
@@ -253,6 +253,12 @@ class WhisperFileTranscriber(FileTranscriber):
     def transcribe_faster_whisper(cls, task: FileTranscriptionTask) -> List[Segment]:
         # Use the already-resolved local model path so we never hit the network
         model_size_or_path = task.model_path
+        if not model_size_or_path:
+            raise FileNotFoundError(
+                "Faster Whisper model is not available locally. "
+                "Check BUZZ_MODEL_ROOT and download the model into that cache first."
+            )
+            return []
 
         model_root_dir = user_cache_dir("Buzz")
         model_root_dir = os.path.join(model_root_dir, "models")

--- a/buzz/transcriber/whisper_file_transcriber.py
+++ b/buzz/transcriber/whisper_file_transcriber.py
@@ -22,7 +22,7 @@ from PyQt6.QtCore import QObject
 
 from buzz import whisper_audio
 from buzz.conn import pipe_stderr
-from buzz.model_loader import ModelType, WhisperModelSize, map_language_to_mms
+from buzz.model_loader import ModelType, map_language_to_mms
 from buzz.transformers_whisper import TransformersTranscriber
 from buzz.transcriber.file_transcriber import FileTranscriber
 from buzz.transcriber.transcriber import FileTranscriptionTask, Segment, Task, DEFAULT_WHISPER_TEMPERATURE
@@ -251,10 +251,8 @@ class WhisperFileTranscriber(FileTranscriber):
 
     @classmethod
     def transcribe_faster_whisper(cls, task: FileTranscriptionTask) -> List[Segment]:
-        if task.transcription_options.model.whisper_model_size == WhisperModelSize.CUSTOM:
-            model_size_or_path = task.transcription_options.model.hugging_face_model_id
-        else:
-            model_size_or_path = task.transcription_options.model.whisper_model_size.to_faster_whisper_model_size()
+        # Use the already-resolved local model path so we never hit the network
+        model_size_or_path = task.model_path
 
         model_root_dir = user_cache_dir("Buzz")
         model_root_dir = os.path.join(model_root_dir, "models")

--- a/buzz/widgets/application.py
+++ b/buzz/widgets/application.py
@@ -3,6 +3,7 @@ import os
 import sys
 import locale
 import platform
+import threading
 import darkdetect
 
 from posthog import Posthog
@@ -85,7 +86,7 @@ class Application(QApplication):
                 "machine": platform.machine(),
                 "version": platform.version(),
             })
-            posthog.shutdown()
+            threading.Thread(target=posthog.shutdown, daemon=True).start()
 
         logging.debug(f"Launching Buzz: {VERSION}, " 
                       f"locale: {locale.getlocale()}, "

--- a/buzz/widgets/application.py
+++ b/buzz/widgets/application.py
@@ -85,6 +85,7 @@ class Application(QApplication):
                 "machine": platform.machine(),
                 "version": platform.version(),
             })
+            posthog.shutdown()
 
         logging.debug(f"Launching Buzz: {VERSION}, " 
                       f"locale: {locale.getlocale()}, "

--- a/buzz/widgets/transcriber/file_transcriber_widget.py
+++ b/buzz/widgets/transcriber/file_transcriber_widget.py
@@ -132,6 +132,13 @@ class FileTranscriberWidget(QWidget):
     def on_model_loaded(self, model_path: str):
         self.reset_transcriber_controls()
 
+        if model_path == "" and self.transcription_options.model.model_type != ModelType.OPEN_AI_WHISPER_API:
+            show_model_download_error_dialog(
+                self,
+                self.tr("Model path is empty. Check BUZZ_MODEL_ROOT and ensure the model is available offline"),
+            )
+            return
+
         self.triggered.emit(
             (self.transcription_options, self.file_transcription_options, model_path)
         )

--- a/scripts/download-models.py
+++ b/scripts/download-models.py
@@ -1,0 +1,113 @@
+"""Download Buzz models for offline / air-gapped deployment.
+
+Set BUZZ_MODEL_ROOT to control where models are stored:
+
+    BUZZ_MODEL_ROOT=/mnt/nfs/buzz-models uv run python scripts/download-models.py
+
+Without filters, downloads all standard sizes for all backends.
+Use --model-type and --model-size to download selectively:
+
+    uv run python scripts/download-models.py --model-type fasterwhisper --model-size small
+    uv run python scripts/download-models.py --model-type whispercpp --model-size tiny base small
+"""
+
+import argparse
+import sys
+
+from PyQt6.QtCore import QCoreApplication
+
+from buzz.model_loader import (
+    ModelType,
+    WhisperModelSize,
+    TranscriptionModel,
+    ModelDownloader,
+    model_root_dir,
+)
+
+# CLI name -> ModelType mapping (matches buzz/cli.py convention)
+MODEL_TYPE_MAP = {
+    "whisper": ModelType.WHISPER,
+    "whispercpp": ModelType.WHISPER_CPP,
+    "fasterwhisper": ModelType.FASTER_WHISPER,
+}
+
+# Standard sizes to download (excludes CUSTOM and LUMII)
+STANDARD_SIZES = [s for s in WhisperModelSize if s not in (WhisperModelSize.CUSTOM, WhisperModelSize.LUMII)]
+
+
+def download(model_types, model_sizes):
+    total = len(model_types) * len(model_sizes)
+    done = 0
+    failed = []
+
+    for mt in model_types:
+        for size in model_sizes:
+            done += 1
+            label = f"[{done}/{total}] {mt.value} / {size.value}"
+
+            model = TranscriptionModel(model_type=mt, whisper_model_size=size)
+            if model.get_local_model_path() is not None:
+                print(f"{label} — already present, skipping")
+                continue
+
+            print(f"{label} — downloading...")
+            downloader = ModelDownloader(model=model)
+            downloader.signals.error.connect(lambda e, lbl=label: failed.append((lbl, e)))
+            downloader.run()
+
+            if model.get_local_model_path() is not None:
+                print(f"{label} — done")
+            else:
+                print(f"{label} — FAILED", file=sys.stderr)
+                failed.append((label, "model path not found after download"))
+
+    return failed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download Buzz models for offline use")
+    parser.add_argument(
+        "--model-type",
+        choices=list(MODEL_TYPE_MAP.keys()),
+        nargs="+",
+        help="Model backends to download (default: all)",
+    )
+    parser.add_argument(
+        "--model-size",
+        choices=[s.value for s in STANDARD_SIZES],
+        nargs="+",
+        help="Model sizes to download (default: all standard sizes)",
+    )
+    args = parser.parse_args()
+
+    model_types = (
+        [MODEL_TYPE_MAP[t] for t in args.model_type]
+        if args.model_type
+        else list(MODEL_TYPE_MAP.values())
+    )
+    model_sizes = (
+        [WhisperModelSize(s) for s in args.model_size]
+        if args.model_size
+        else STANDARD_SIZES
+    )
+
+    print(f"Model root: {model_root_dir}")
+    print(f"Backends:   {', '.join(t.value for t in model_types)}")
+    print(f"Sizes:      {', '.join(s.value for s in model_sizes)}")
+    print()
+
+    failed = download(model_types, model_sizes)
+
+    if failed:
+        print(f"\n{len(failed)} download(s) failed:", file=sys.stderr)
+        for label, err in failed:
+            print(f"  {label}: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    print("\nAll downloads complete.")
+
+
+if __name__ == "__main__":
+    # Minimal Qt app needed for PyQt signal machinery in ModelDownloader
+    app = QCoreApplication(sys.argv)
+    main()

--- a/scripts/download-models.py
+++ b/scripts/download-models.py
@@ -12,7 +12,13 @@ Use --model-type and --model-size to download selectively:
 """
 
 import argparse
+import os
 import sys
+
+# Mirror the HF_HOME logic from buzz/buzz.py so downloads go to the right place
+_model_root = os.environ.get("BUZZ_MODEL_ROOT")
+if _model_root:
+    os.environ.setdefault("HF_HOME", os.path.dirname(_model_root))
 
 from PyQt6.QtCore import QCoreApplication
 

--- a/share/metainfo/io.github.chidiwilliams.Buzz.metainfo.xml
+++ b/share/metainfo/io.github.chidiwilliams.Buzz.metainfo.xml
@@ -26,8 +26,6 @@
 
   <url type="bugtracker">https://github.com/chidiwilliams/buzz/issues</url>
   <url type="homepage">https://github.com/chidiwilliams/buzz</url>
-  <url type="faq">https://chidiwilliams.github.io/buzz/docs</url>
-  <url type="vcs-browser">https://github.com/chidiwilliams/buzz</url>
 
   <branding>
     <color type="primary" scheme_preference="light">#f66151</color>

--- a/share/metainfo/io.github.chidiwilliams.Buzz.metainfo.xml
+++ b/share/metainfo/io.github.chidiwilliams.Buzz.metainfo.xml
@@ -26,6 +26,8 @@
 
   <url type="bugtracker">https://github.com/chidiwilliams/buzz/issues</url>
   <url type="homepage">https://github.com/chidiwilliams/buzz</url>
+  <url type="faq">https://chidiwilliams.github.io/buzz/docs</url>
+  <url type="vcs-browser">https://github.com/chidiwilliams/buzz</url>
 
   <branding>
     <color type="primary" scheme_preference="light">#f66151</color>

--- a/tests/model_loader_test.py
+++ b/tests/model_loader_test.py
@@ -182,6 +182,26 @@ class TestTranscriptionModel:
         assert model.model_type in list(ModelType)
         assert model.model_type.is_available() is True
 
+    def test_default_respects_model_type_env(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_DEFAULT_MODEL_TYPE", "Faster Whisper")
+        model = TranscriptionModel.default()
+        assert model.model_type == ModelType.FASTER_WHISPER
+
+    def test_default_respects_model_size_env(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_DEFAULT_MODEL_SIZE", "base")
+        model = TranscriptionModel.default()
+        assert model.whisper_model_size == WhisperModelSize.BASE
+
+    def test_default_invalid_model_type_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_DEFAULT_MODEL_TYPE", "NotAModelType")
+        model = TranscriptionModel.default()
+        assert model.model_type.is_available() is True
+
+    def test_default_invalid_model_size_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_DEFAULT_MODEL_SIZE", "not-a-size")
+        model = TranscriptionModel.default()
+        assert model.whisper_model_size == WhisperModelSize.TINY
+
     def test_get_local_model_path_openai_api(self):
         model = TranscriptionModel(model_type=ModelType.OPEN_AI_WHISPER_API)
         assert model.get_local_model_path() == ""

--- a/tests/transcriber/whisper_file_transcriber_test.py
+++ b/tests/transcriber/whisper_file_transcriber_test.py
@@ -428,4 +428,21 @@ class TestWhisperFileTranscriber:
         # Assert that file was not created
         assert os.path.isfile(output_file_path) is False
 
+
+class TestTranscribeFasterWhisper:
+    def test_raises_when_model_path_is_empty(self):
+        task = FileTranscriptionTask(
+            model_path="",
+            transcription_options=TranscriptionOptions(
+                model=TranscriptionModel(
+                    model_type=ModelType.FASTER_WHISPER,
+                    whisper_model_size=WhisperModelSize.TINY,
+                )
+            ),
+            file_transcription_options=FileTranscriptionOptions(file_paths=[test_audio_path]),
+            file_path=test_audio_path,
+        )
+        with pytest.raises(FileNotFoundError, match="BUZZ_MODEL_ROOT"):
+            WhisperFileTranscriber.transcribe_faster_whisper(task)
+
         time.sleep(3)

--- a/tests/widgets/file_transcriber_widget_test.py
+++ b/tests/widgets/file_transcriber_widget_test.py
@@ -48,7 +48,8 @@ class TestFileTranscriberWidget:
         mock_triggered = Mock()
         widget.triggered.connect(mock_triggered)
 
-        with patch("buzz.widgets.transcriber.file_transcriber_widget.show_model_download_error_dialog") as mock_err:
+        with patch("buzz.widgets.transcriber.file_transcriber_widget.show_model_download_error_dialog") as mock_err, \
+             patch.object(widget, "save_preferences"):
             widget.on_model_loaded("")
             mock_err.assert_called_once()
             mock_triggered.assert_not_called()
@@ -63,7 +64,8 @@ class TestFileTranscriberWidget:
         mock_triggered = Mock()
         widget.triggered.connect(mock_triggered)
 
-        with patch("buzz.widgets.transcriber.file_transcriber_widget.show_model_download_error_dialog") as mock_err:
+        with patch("buzz.widgets.transcriber.file_transcriber_widget.show_model_download_error_dialog") as mock_err, \
+             patch.object(widget, "save_preferences"):
             widget.on_model_loaded("")
             mock_err.assert_not_called()
             mock_triggered.assert_called_once()

--- a/tests/widgets/file_transcriber_widget_test.py
+++ b/tests/widgets/file_transcriber_widget_test.py
@@ -1,8 +1,10 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from PyQt6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
+from buzz.model_loader import ModelType, TranscriptionModel
+from buzz.transcriber.transcriber import TranscriptionOptions
 from buzz.widgets.transcriber.file_transcriber_widget import FileTranscriberWidget
 from tests.audio import test_audio_path
 
@@ -35,3 +37,33 @@ class TestFileTranscriberWidget:
         assert transcription_options.language is None
         assert file_transcription_options.file_paths == [test_audio_path]
         assert len(model_path) > 0
+
+    def test_on_model_loaded_empty_path_shows_error_for_local_model(self, qtbot: QtBot):
+        widget = FileTranscriberWidget(file_paths=[test_audio_path])
+        qtbot.add_widget(widget)
+        widget.transcription_options = TranscriptionOptions(
+            model=TranscriptionModel(model_type=ModelType.FASTER_WHISPER)
+        )
+
+        mock_triggered = Mock()
+        widget.triggered.connect(mock_triggered)
+
+        with patch("buzz.widgets.transcriber.file_transcriber_widget.show_model_download_error_dialog") as mock_err:
+            widget.on_model_loaded("")
+            mock_err.assert_called_once()
+            mock_triggered.assert_not_called()
+
+    def test_on_model_loaded_empty_path_allowed_for_openai_api(self, qtbot: QtBot):
+        widget = FileTranscriberWidget(file_paths=[test_audio_path])
+        qtbot.add_widget(widget)
+        widget.transcription_options = TranscriptionOptions(
+            model=TranscriptionModel(model_type=ModelType.OPEN_AI_WHISPER_API)
+        )
+
+        mock_triggered = Mock()
+        widget.triggered.connect(mock_triggered)
+
+        with patch("buzz.widgets.transcriber.file_transcriber_widget.show_model_download_error_dialog") as mock_err:
+            widget.on_model_loaded("")
+            mock_err.assert_not_called()
+            mock_triggered.assert_called_once()

--- a/tests/widgets/main_window_test.py
+++ b/tests/widgets/main_window_test.py
@@ -19,7 +19,10 @@ from pytestqt.qtbot import QtBot
 from buzz.locale import _
 from buzz.db.entity.transcription import Transcription
 from buzz.db.service.transcription_service import TranscriptionService
+from buzz.model_loader import TranscriptionModel, ModelType, WhisperModelSize
+from buzz.transcriber.transcriber import Task, OutputFormat
 from buzz.widgets.main_window import MainWindow
+from buzz.widgets.preferences_dialog.models.file_transcription_preferences import FileTranscriptionPreferences
 from buzz.widgets.transcriber.file_transcriber_widget import FileTranscriberWidget
 
 mock_transcriptions: List[Transcription] = [
@@ -359,9 +362,27 @@ class TestMainWindow:
     def _import_file_and_start_transcription(
         window: MainWindow, long_audio: bool = False
     ):
+        default_prefs = FileTranscriptionPreferences(
+            language=None,
+            task=Task.TRANSCRIBE,
+            model=TranscriptionModel(
+                model_type=ModelType.WHISPER,
+                whisper_model_size=WhisperModelSize.TINY,
+            ),
+            word_level_timings=False,
+            extract_speech=False,
+            initial_prompt="",
+            enable_llm_translation=False,
+            llm_prompt="",
+            llm_model="",
+            output_formats={OutputFormat.TXT},
+        )
+
         with patch(
             "PyQt6.QtWidgets.QFileDialog.getOpenFileNames"
-        ) as open_file_names_mock:
+        ) as open_file_names_mock, patch.object(
+            FileTranscriberWidget, "load_preferences", return_value=default_prefs
+        ):
             open_file_names_mock.return_value = (
                 [
                     get_test_asset(


### PR DESCRIPTION
## Summary

This PR adds Linux AppImage packaging and improves offline/air-gapped deployment support:

- **AppImage build**: Reuses the existing PyInstaller infrastructure (`Buzz.spec`) and wraps the output with `appimagetool`. Integrated into CI for automated builds and GitHub releases.
- **Fix Faster Whisper offline transcription**: `transcribe_faster_whisper()` was passing the model size name to `faster_whisper.WhisperModel()`, which tries to resolve it via HuggingFace Hub. Now uses the already-resolved local `task.model_path`, consistent with `recording_transcriber.py`.
- **Fix app hanging on exit**: Run `posthog.shutdown()` in a daemon thread after capture so the background flush never blocks the main thread or app exit.
- **Link `HF_HOME` to `BUZZ_MODEL_ROOT`**: When `BUZZ_MODEL_ROOT` is set, derive `HF_HOME` from it so all HuggingFace operations (including MMS adapter downloads) respect the custom model location.
- **Configurable default model**: New `BUZZ_DEFAULT_MODEL_TYPE` and `BUZZ_DEFAULT_MODEL_SIZE` env vars let administrators preconfigure which model new users start with.
- **Bulk model download script**: `scripts/download-models.py` downloads all standard models for offline pre-staging, with optional `--model-type` and `--model-size` filters.
- **Fix AppImage CI**: Replace unsupported `--appimage-extract-and-run` CLI argument with `APPIMAGETOOL_EXTRACT_AND_RUN=1` env var (the correct way to run appimagetool without FUSE in CI).

## Motivation

These changes enable deploying Buzz in air-gapped / corporate environments where:
1. Users cannot download models at runtime
2. Models are pre-staged on shared storage (e.g., NFS)
3. A default model must be preconfigured centrally
4. AppImage is preferred over Snap/Flatpak for distribution flexibility

## New environment variables

| Variable | Default | Purpose |
|---|---|---|
| `BUZZ_DEFAULT_MODEL_TYPE` | First available | Preconfigure the default model backend (e.g., `Faster Whisper`) |
| `BUZZ_DEFAULT_MODEL_SIZE` | `tiny` | Preconfigure the default model size (e.g., `large-v3-turbo`) |

Existing `BUZZ_MODEL_ROOT` is unchanged — this PR fixes `HF_HOME` to derive from it when set.

## Example: offline deployment workflow

```bash
# 1. On a machine with internet, pre-download models to shared storage
BUZZ_MODEL_ROOT=/mnt/nfs/buzz-models uv run python scripts/download-models.py \
    --model-type fasterwhisper --model-size large-v3-turbo

# 2. On air-gapped machines, set env vars and run
export BUZZ_MODEL_ROOT=/mnt/nfs/buzz-models
export BUZZ_DEFAULT_MODEL_TYPE="Faster Whisper"
export BUZZ_DEFAULT_MODEL_SIZE="large-v3-turbo"
export BUZZ_DISABLE_TELEMETRY=1
./Buzz-1.4.4-x86_64.AppImage
```

## Test plan

- [x] Unit tests: `BUZZ_DEFAULT_MODEL_TYPE` / `BUZZ_DEFAULT_MODEL_SIZE` env vars (valid values, invalid fallback)
- [x] Unit tests: `on_model_loaded("")` shows error dialog for local models, passes through for OpenAI API
- [x] Unit tests: `transcribe_faster_whisper` raises `FileNotFoundError` when `model_path` is empty
- [x] `uv run make bundle_appimage` produces a working AppImage on Ubuntu
- [x] AppImage launches and transcribes audio
- [x] `BUZZ_MODEL_ROOT=/tmp/test uv run python scripts/download-models.py --model-type fasterwhisper --model-size tiny` downloads to custom path
- [x] App finds models in custom `BUZZ_MODEL_ROOT` without network access
- [x] App exits cleanly without hanging (posthog fix)
- [x] Faster Whisper transcription works offline without HuggingFace Hub access
- [ ] CI AppImage build job succeeds on ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)