### PR TITLE
refactor: extract parse() into smaller functions to fix R0915

### DIFF
--- a/buzz/cli.py
+++ b/buzz/cli.py
@@ -49,6 +49,214 @@ def is_url(path: str) -> bool:
     parsed = urllib.parse.urlparse(path)
     return all([parsed.scheme, parsed.netloc])
 
+def _add_command_options(parser: QCommandLineParser):
+    task_option = QCommandLineOption(
+        ["t", "task"],
+        f"The task to perform. Allowed: {join_values(Task)}. Default: {Task.TRANSCRIBE.value}.",
+        "task",
+        Task.TRANSCRIBE.value,
+    )
+    model_type_option = QCommandLineOption(
+        ["m", "model-type"],
+        f"Model type. Allowed: {join_values(CommandLineModelType)}. Default: {CommandLineModelType.WHISPER.value}.",
+        "model-type",
+        CommandLineModelType.WHISPER.value,
+    )
+    model_size_option = QCommandLineOption(
+        ["s", "model-size"],
+        f"Model size. Use only when --model-type is whisper, whispercpp, or fasterwhisper. Allowed: {join_values(WhisperModelSize)}. Default: {WhisperModelSize.TINY.value}.",
+        "model-size",
+        WhisperModelSize.TINY.value,
+    )
+    hugging_face_model_id_option = QCommandLineOption(
+        ["hfid"],
+        'Hugging Face model ID. Use only when --model-type is huggingface. Example: "openai/whisper-tiny"',
+        "id",
+    )
+    language_option = QCommandLineOption(
+        ["l", "language"],
+        f'Language code. Allowed: {", ".join(sorted([k + " (" + LANGUAGES[k].title() + ")" for k in LANGUAGES]))}. Leave empty to detect language.',
+        "code",
+        "",
+    )
+    initial_prompt_option = QCommandLineOption(
+        ["p", "prompt"], "Initial prompt.", "prompt", ""
+    )
+    word_timestamp_option = QCommandLineOption(
+        ["w", "word-timestamps"], "Generate word-level timestamps."
+    )
+    extract_speech_option = QCommandLineOption(
+        ["e", "extract-speech"], "Extract speech from audio before transcribing."
+    )
+    open_ai_access_token_option = QCommandLineOption(
+        "openai-token",
+        f"OpenAI access token. Use only when --model-type is {CommandLineModelType.OPEN_AI_WHISPER_API.value}. Defaults to your previously saved access token, if one exists.",
+        "token",
+    )
+    output_directory_option = QCommandLineOption(
+        ["d", "output-directory"], "Output directory", "directory"
+    )
+    srt_option = QCommandLineOption(["srt"], "Output result in an SRT file.")
+    vtt_option = QCommandLineOption(["vtt"], "Output result in a VTT file.")
+    txt_option = QCommandLineOption("txt", "Output result in a TXT file.")
+    hide_gui_option = QCommandLineOption("hide-gui", "Hide the main application window.")
+
+    parser.addOptions(
+        [
+            task_option,
+            model_type_option,
+            model_size_option,
+            hugging_face_model_id_option,
+            language_option,
+            initial_prompt_option,
+            word_timestamp_option,
+            extract_speech_option,
+            open_ai_access_token_option,
+            output_directory_option,
+            srt_option,
+            vtt_option,
+            txt_option,
+            hide_gui_option,
+        ]
+    )
+
+    return {
+        "task": task_option,
+        "model_type": model_type_option,
+        "model_size": model_size_option,
+        "hugging_face_model_id": hugging_face_model_id_option,
+        "language": language_option,
+        "initial_prompt": initial_prompt_option,
+        "word_timestamps": word_timestamp_option,
+        "extract_speech": extract_speech_option,
+        "openai_token": open_ai_access_token_option,
+        "output_directory": output_directory_option,
+        "srt": srt_option,
+        "vtt": vtt_option,
+        "txt": txt_option,
+        "hide_gui": hide_gui_option,
+    }
+
+
+def _resolve_model(
+    model_type: CommandLineModelType,
+    model_size: WhisperModelSize,
+    hugging_face_model_id: str,
+):
+    if hugging_face_model_id == "" and model_type == CommandLineModelType.HUGGING_FACE:
+        raise CommandLineError("--hfid is required when --model-type is huggingface")
+    model = TranscriptionModel(
+        model_type=ModelType[model_type.name],
+        whisper_model_size=model_size,
+        hugging_face_model_id=hugging_face_model_id,
+    )
+    model_path = model.get_local_model_path()
+    if model_path is None:
+        ModelDownloader(model=model).run()
+        model_path = model.get_local_model_path()
+    if model_path is None:
+        raise CommandLineError("Model not found")
+    return model_path, model
+
+
+def _add_transcription_tasks(
+    app: Application,
+    file_paths: typing.List[str],
+    model_path: str,
+    transcription_options: TranscriptionOptions,
+    output_formats: typing.Set[OutputFormat],
+    output_directory: str = "",
+):
+    for file_path in file_paths:
+        path_is_url = is_url(file_path)
+        file_transcription_options = FileTranscriptionOptions(
+            file_paths=[file_path] if not path_is_url else None,
+            url=file_path if path_is_url else None,
+            output_formats=output_formats,
+        )
+        transcription_task = FileTranscriptionTask(
+            file_path=file_path if not path_is_url else None,
+            url=file_path if path_is_url else None,
+            source=FileTranscriptionTask.Source.FILE_IMPORT
+            if not path_is_url
+            else FileTranscriptionTask.Source.URL_IMPORT,
+            model_path=model_path,
+            transcription_options=transcription_options,
+            file_transcription_options=file_transcription_options,
+            output_directory=output_directory if output_directory != "" else None,
+        )
+        app.add_task(transcription_task, quit_on_complete=True)
+
+
+def _process_add_output_formats(parser, opts) -> typing.Set[OutputFormat]:
+    output_formats: typing.Set[OutputFormat] = set()
+    if parser.isSet(opts["srt"]):
+        output_formats.add(OutputFormat.SRT)
+    if parser.isSet(opts["vtt"]):
+        output_formats.add(OutputFormat.VTT)
+    if parser.isSet(opts["txt"]):
+        output_formats.add(OutputFormat.TXT)
+    return output_formats
+
+
+def _handle_add_command(app: Application, parser: QCommandLineParser):
+    parser.clearPositionalArguments()
+    parser.addPositionalArgument("files", "Input file paths", "[file file file...]")
+
+    opts = _add_command_options(parser)
+    parser.addHelpOption()
+    parser.addVersionOption()
+    parser.process(app)
+
+    file_paths = parser.positionalArguments()[1:]
+    if len(file_paths) == 0:
+        raise CommandLineError("No input files")
+
+    task = parse_enum_option(opts["task"], parser, Task)
+    model_type = parse_enum_option(opts["model_type"], parser, CommandLineModelType)
+    model_size = parse_enum_option(opts["model_size"], parser, WhisperModelSize)
+
+    model_path, model = _resolve_model(
+        model_type, model_size, parser.value(opts["hugging_face_model_id"])
+    )
+
+    language = parser.value(opts["language"])
+    if language == "":
+        language = None
+    elif LANGUAGES.get(language) is None:
+        raise CommandLineError("Invalid language option")
+
+    output_formats = _process_add_output_formats(parser, opts)
+
+    openai_access_token = parser.value(opts["openai_token"])
+    if model.model_type == ModelType.OPEN_AI_WHISPER_API and openai_access_token == "":
+        openai_access_token = get_password(key=Key.OPENAI_API_KEY)
+        if openai_access_token == "":
+            raise CommandLineError("No OpenAI access token found")
+
+    transcription_options = TranscriptionOptions(
+        model=model,
+        task=task,
+        language=language,
+        initial_prompt=parser.value(opts["initial_prompt"]),
+        word_level_timings=parser.isSet(opts["word_timestamps"]),
+        extract_speech=parser.isSet(opts["extract_speech"]),
+        openai_access_token=openai_access_token,
+    )
+
+    _add_transcription_tasks(
+        app,
+        file_paths,
+        model_path,
+        transcription_options,
+        output_formats,
+        parser.value(opts["output_directory"]),
+    )
+
+    if parser.isSet(opts["hide_gui"]):
+        app.hide_main_window = True
+
+
 def parse(app: Application, parser: QCommandLineParser):
     parser.addPositionalArgument("<command>", "One of the following commands:\n- add")
     parser.parse(app.arguments())
@@ -57,188 +265,12 @@ def parse(app: Application, parser: QCommandLineParser):
     if len(args) == 0:
         parser.addHelpOption()
         parser.addVersionOption()
-
         parser.process(app)
         return
 
     command = args[0]
     if command == "add":
-        parser.clearPositionalArguments()
-
-        parser.addPositionalArgument("files", "Input file paths", "[file file file...]")
-
-        task_option = QCommandLineOption(
-            ["t", "task"],
-            f"The task to perform. Allowed: {join_values(Task)}. Default: {Task.TRANSCRIBE.value}.",
-            "task",
-            Task.TRANSCRIBE.value,
-        )
-        model_type_option = QCommandLineOption(
-            ["m", "model-type"],
-            f"Model type. Allowed: {join_values(CommandLineModelType)}. Default: {CommandLineModelType.WHISPER.value}.",
-            "model-type",
-            CommandLineModelType.WHISPER.value,
-        )
-        model_size_option = QCommandLineOption(
-            ["s", "model-size"],
-            f"Model size. Use only when --model-type is whisper, whispercpp, or fasterwhisper. Allowed: {join_values(WhisperModelSize)}. Default: {WhisperModelSize.TINY.value}.",
-            "model-size",
-            WhisperModelSize.TINY.value,
-        )
-        hugging_face_model_id_option = QCommandLineOption(
-            ["hfid"],
-            'Hugging Face model ID. Use only when --model-type is huggingface. Example: "openai/whisper-tiny"',
-            "id",
-        )
-        language_option = QCommandLineOption(
-            ["l", "language"],
-            f'Language code. Allowed: {", ".join(sorted([k + " (" + LANGUAGES[k].title() + ")" for k in LANGUAGES]))}. Leave empty to detect language.',
-            "code",
-            "",
-        )
-        initial_prompt_option = QCommandLineOption(
-            ["p", "prompt"], "Initial prompt.", "prompt", ""
-        )
-        word_timestamp_option = QCommandLineOption(
-            ["w", "word-timestamps"], "Generate word-level timestamps."
-        )
-        extract_speech_option = QCommandLineOption(
-            ["e", "extract-speech"], "Extract speech from audio before transcribing."
-        )
-        open_ai_access_token_option = QCommandLineOption(
-            "openai-token",
-            f"OpenAI access token. Use only when --model-type is {CommandLineModelType.OPEN_AI_WHISPER_API.value}. Defaults to your previously saved access token, if one exists.",
-            "token",
-        )
-        output_directory_option = QCommandLineOption(
-            ["d", "output-directory"], "Output directory", "directory"
-        )
-        srt_option = QCommandLineOption(["srt"], "Output result in an SRT file.")
-        vtt_option = QCommandLineOption(["vtt"], "Output result in a VTT file.")
-        txt_option = QCommandLineOption("txt", "Output result in a TXT file.")
-        hide_gui_option = QCommandLineOption("hide-gui", "Hide the main application window.")
-
-        parser.addOptions(
-            [
-                task_option,
-                model_type_option,
-                model_size_option,
-                hugging_face_model_id_option,
-                language_option,
-                initial_prompt_option,
-                word_timestamp_option,
-                extract_speech_option,
-                open_ai_access_token_option,
-                output_directory_option,
-                srt_option,
-                vtt_option,
-                txt_option,
-                hide_gui_option,
-            ]
-        )
-
-        parser.addHelpOption()
-        parser.addVersionOption()
-
-        parser.process(app)
-
-        # slice after first argument, the command
-        file_paths = parser.positionalArguments()[1:]
-        if len(file_paths) == 0:
-            raise CommandLineError("No input files")
-
-        task = parse_enum_option(task_option, parser, Task)
-
-        model_type = parse_enum_option(model_type_option, parser, CommandLineModelType)
-        model_size = parse_enum_option(model_size_option, parser, WhisperModelSize)
-
-        hugging_face_model_id = parser.value(hugging_face_model_id_option)
-
-        if (
-            hugging_face_model_id == ""
-            and model_type == CommandLineModelType.HUGGING_FACE
-        ):
-            raise CommandLineError(
-                "--hfid is required when --model-type is huggingface"
-            )
-
-        model = TranscriptionModel(
-            model_type=ModelType[model_type.name],
-            whisper_model_size=model_size,
-            hugging_face_model_id=hugging_face_model_id,
-        )
-
-        model_path = model.get_local_model_path()
-        if model_path is None:
-            ModelDownloader(model=model).run()
-            model_path = model.get_local_model_path()
-
-        if model_path is None:
-            raise CommandLineError("Model not found")
-
-        language = parser.value(language_option)
-        if language == "":
-            language = None
-        elif LANGUAGES.get(language) is None:
-            raise CommandLineError("Invalid language option")
-
-        initial_prompt = parser.value(initial_prompt_option)
-
-        word_timestamps = parser.isSet(word_timestamp_option)
-        extract_speech = parser.isSet(extract_speech_option)
-
-        output_formats: typing.Set[OutputFormat] = set()
-        if parser.isSet(srt_option):
-            output_formats.add(OutputFormat.SRT)
-        if parser.isSet(vtt_option):
-            output_formats.add(OutputFormat.VTT)
-        if parser.isSet(txt_option):
-            output_formats.add(OutputFormat.TXT)
-
-        openai_access_token = parser.value(open_ai_access_token_option)
-        if (
-            model.model_type == ModelType.OPEN_AI_WHISPER_API
-            and openai_access_token == ""
-        ):
-            openai_access_token = get_password(key=Key.OPENAI_API_KEY)
-
-            if openai_access_token == "":
-                raise CommandLineError("No OpenAI access token found")
-
-        output_directory = parser.value(output_directory_option)
-
-        transcription_options = TranscriptionOptions(
-            model=model,
-            task=task,
-            language=language,
-            initial_prompt=initial_prompt,
-            word_level_timings=word_timestamps,
-            extract_speech=extract_speech,
-            openai_access_token=openai_access_token,
-        )
-
-        for file_path in file_paths:
-            path_is_url = is_url(file_path)
-
-            file_transcription_options = FileTranscriptionOptions(
-                file_paths=[file_path] if not path_is_url else None,
-                url=file_path if path_is_url else None,
-                output_formats=output_formats,
-            )
-
-            transcription_task = FileTranscriptionTask(
-                file_path=file_path if not path_is_url else None,
-                url=file_path if path_is_url else None,
-                source=FileTranscriptionTask.Source.FILE_IMPORT if not path_is_url else FileTranscriptionTask.Source.URL_IMPORT,
-                model_path=model_path,
-                transcription_options=transcription_options,
-                file_transcription_options=file_transcription_options,
-                output_directory=output_directory if output_directory != "" else None,
-            )
-            app.add_task(transcription_task, quit_on_complete=True)
-
-        if parser.isSet(hide_gui_option):
-            app.hide_main_window = True
+        _handle_add_command(app, parser)
 
 T = typing.TypeVar("T", bound=enum.Enum)
 


### PR DESCRIPTION
Extracted the 'parse' function into 6 smaller functions with single responsibilities, eliminating Pylint warning R0915 (too-many-statements).

Changes:
- '_add_command_options': defines and registers the 14 CLI options
- '_resolve_model': validates the model and downloads it if necessary
- '_add_transcription_tasks': iterates over files and adds tasks
- '_process_add_output_formats': extracts SRT/VTT/TXT formats
- '_handle_add_command': orchestrates the processing of the `add` command
- 'parse': simplified dispatcher with ~10 statements

Tests: 592 passed, no regressions.