### PR TITLE
feat: add history detection for already-transcribed files

### DIFF
--- a/buzz/transcriber/transcriber.py
+++ b/buzz/transcriber/transcriber.py
@@ -180,6 +180,7 @@ class FileTranscriptionTask:
         COMPLETED = "completed"
         FAILED = "failed"
         CANCELED = "canceled"
+        HISTORY = "history"
 
     class Source(enum.Enum):
         FILE_IMPORT = "file_import"

--- a/buzz/widgets/main_window.py
+++ b/buzz/widgets/main_window.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import logging
 from typing import Tuple, List, Optional
@@ -54,6 +55,23 @@ from buzz.widgets.transcription_tasks_table_widget import (
 from buzz.widgets.transcription_viewer.transcription_viewer_widget import (
     TranscriptionViewerWidget,
 )
+
+
+def _has_existing_output(file_path: str) -> bool:
+    """Return True if any output file already exists for the given audio file.
+
+    Checks for .txt, .srt, and .vtt exports with the same base name
+    as *file_path* in the same directory.  This enables the
+    "already transcribed" history-detection feature.
+    """
+    if not file_path or not os.path.isfile(file_path):
+        return False
+    base_dir = os.path.dirname(file_path)
+    base_name = os.path.splitext(os.path.basename(file_path))[0]
+    for ext in ("txt", "srt", "vtt"):
+        if glob.glob(os.path.join(base_dir, f"{base_name}*.{ext}")):
+            return True
+    return False
 
 
 class MainWindow(QMainWindow):
@@ -218,6 +236,9 @@ class MainWindow(QMainWindow):
                     file_path=file_path,
                     source=FileTranscriptionTask.Source.FILE_IMPORT,
                 )
+                # Detect already-transcribed files (history detection)
+                if _has_existing_output(file_path):
+                    task.status = FileTranscriptionTask.Status.HISTORY
                 self.add_task(task)
         else:
             task = FileTranscriptionTask(
@@ -412,7 +433,9 @@ class MainWindow(QMainWindow):
     def add_task(self, task: FileTranscriptionTask):
         self.transcription_service.create_transcription(task)
         self.table_widget.refresh_all()
-        self.transcriber_worker.add_task(task)
+        # HISTORY tasks have existing output — skip transcription queue
+        if task.status != FileTranscriptionTask.Status.HISTORY:
+            self.transcriber_worker.add_task(task)
 
     def on_transcriptions_updated(self):
         self.table_widget.refresh_all()

--- a/buzz/widgets/transcription_tasks_table_widget.py
+++ b/buzz/widgets/transcription_tasks_table_widget.py
@@ -84,6 +84,8 @@ def format_record_status_text(record: QSqlRecord) -> str:
             return _("Canceled")
         case FileTranscriptionTask.Status.QUEUED:
             return _("Queued")
+        case FileTranscriptionTask.Status.HISTORY:
+            return "✅ " + _("Already Transcribed")
         case _: # Case to handle UNKNOWN status
             return ""
 


### PR DESCRIPTION
## Summary

Detect existing output files when a user adds an audio/video file and mark those tasks as **Already Transcribed** instead of queuing them for re-transcription.

Resolves #1518.

## Problem

Buzz has no memory of past transcriptions. Re-opening the app or pointing it to a folder with previously transcribed files causes it to either ignore them silently or waste time/credits re-transcribing them.

## Solution

When a transcription task is created from a file import, `_has_existing_output()` checks the same directory for any `.txt`, `.srt`, or `.vtt` file sharing the input file's base name. If a match is found:
- `task.status` is set to `FileTranscriptionTask.Status.HISTORY`
- Tasks are persisted to the DB and shown in the table with **Already Transcribed**
- Tasks are **not** added to the transcriber queue (no API/GPU cost)

## Changes

| File | Change |
|------|--------|
| `buzz/transcriber/transcriber.py` | Add `HISTORY` to `FileTranscriptionTask.Status` enum |
| `buzz/widgets/main_window.py` | Add `_has_existing_output()` helper; set HISTORY status at import; skip HISTORY tasks in queue |
| `buzz/widgets/transcription_tasks_table_widget.py` | Format HISTORY status as **Already Transcribed** |

## Testing

Open a folder that already contains `.txt` outputs alongside audio files — tasks should show the "Already Transcribed" badge instead of being re-queued.
