### PR TITLE
Fix: live recording + whisper.cpp + Translate task → "File Not Found (/audio/translations)"

### DIFF
--- a/buzz/transcriber/recording_transcriber.py
+++ b/buzz/transcriber/recording_transcriber.py
@@ -324,12 +324,21 @@ class RecordingTranscriber(QObject):
             }
 
             try:
+                is_local_whisper_cpp_server = (
+                    self.transcription_options.model.model_type == ModelType.WHISPER_CPP
+                )
+
+                use_transcriptions_endpoint = (
+                    self.transcription_options.task == Task.TRANSCRIBE
+                    or is_local_whisper_cpp_server
+                )
+
                 transcript = (
                     self.openai_client.audio.transcriptions.create(
                         **options,
                         language=self.transcription_options.language,
                     )
-                    if self.transcription_options.task == Task.TRANSCRIBE
+                    if use_transcriptions_endpoint
                     else self.openai_client.audio.translations.create(**options)
                 )
 
@@ -471,6 +480,9 @@ class RecordingTranscriber(QObject):
             "--entropy-thold", "2.8",
             "--suppress-nst"
         ]
+
+        if self.transcription_options.task == Task.TRANSLATE:
+            cmd.append("--translate")
 
         if self.transcription_options.language is not None:
             cmd.extend(["--language", self.transcription_options.language])


### PR DESCRIPTION
## Fix: live recording + whisper.cpp + Translate task → "File Not Found (/audio/translations)"

### Bug

Using live recording with the whisper.cpp backend, source language `zh`,
task `Translate`, fails immediately with:
Transcription (task=Transcribe) works fine on the same setup; only
Translate is broken.

### Root cause

`start_local_whisper_server()` boots the bundled `whisper-server` with a
single hardcoded route:

```python
"--inference-path", "/audio/transcriptions",
```

Meanwhile, `_transcribe_via_api()` picks between the OpenAI SDK's
`.audio.transcriptions.create()` and `.audio.translations.create()`
based on task. When task is Translate, the SDK POSTs to
`/audio/translations` — a route the local server never registers — so
the request 404s.

This affects every user running live recording + whisper.cpp + Translate,
not just a specific machine/config. File-based transcription (`whisper_cpp.py`,
which invokes `whisper-cli` directly with a `--translate` flag) is unaffected.

### Fix

whisper.cpp's `whisper-server` supports its own `--translate` flag, which
makes its single endpoint return translated text instead of a same-language
transcript. Two small changes:

1. `start_local_whisper_server()` passes `--translate` to the server
   subprocess when the selected task is Translate.
2. `_transcribe_via_api()` always calls `.audio.transcriptions.create()`
   when the backend is the local whisper.cpp server, since that's the
   only route it exposes — regardless of task.

The OpenAI Whisper API backend (`ModelType.OPEN_AI_WHISPER_API`), which
genuinely exposes both `/audio/transcriptions` and `/audio/translations`
on the real OpenAI API, is unaffected — the transcribe/translate branch
there is preserved exactly as before.

### Testing

- [ ] Live recording, whisper.cpp backend, task=Transcribe, zh → unchanged, returns Chinese text
- [ ] Live recording, whisper.cpp backend, task=Translate, zh → now returns English text, no 404
- [ ] Live recording/API mode, OpenAI Whisper API backend, task=Transcribe → unchanged
- [ ] Live recording/API mode, OpenAI Whisper API backend, task=Translate → unchanged
- [ ] File-based transcription (whisper.cpp, Translate) → unaffected, still uses whisper-cli directly

### Notes for reviewers

No new endpoints, no changes to file-based transcription, no changes to
faster-whisper/Hugging Face code paths. Scope is limited to the
live-recording + local-whisper.cpp-server code path.