### PR TITLE
Fix transcript resizer timestamp conversion

### DIFF
--- a/buzz/plugins/transcript_resizer/plugin.py
+++ b/buzz/plugins/transcript_resizer/plugin.py
@@ -186,8 +186,8 @@ class TranscriptResizerPlugin(BuzzPlugin):
                 words.append(
                     {
                         "word": buzz_segment.text + separator,
-                        "start": buzz_segment.start_time / 100,
-                        "end": buzz_segment.end_time / 100,
+                        "start": buzz_segment.start_time / 1000,
+                        "end": buzz_segment.end_time / 1000,
                     }
                 )
                 text += buzz_segment.text + separator
@@ -215,8 +215,8 @@ class TranscriptResizerPlugin(BuzzPlugin):
 
         return [
             Segment(
-                start=int(segment.start * 100),
-                end=int(segment.end * 100),
+                start=int(segment.start * 1000),
+                end=int(segment.end * 1000),
                 text=segment.text,
             )
             for segment in result.segments

--- a/tests/plugins/plugin_system_test.py
+++ b/tests/plugins/plugin_system_test.py
@@ -335,7 +335,7 @@ def test_transcript_resizer_regroups_with_word_timings(tmp_path, monkeypatch):
     assert len(captured["segs"]) == 1
     assert captured["segs"][0].text == "Hello. World."
     assert captured["segs"][0].start == 0
-    assert captured["segs"][0].end == 200  # 2.0s * 100
+    assert captured["segs"][0].end == 2000  # 2.0s * 100
 
 
 def test_export_docx_loads():


### PR DESCRIPTION
## Summary

Fix incorrect timestamp conversion in the Automatic Transcript Resizer plugin.

The transcript resizer uses `stable_whisper`'s regroup functionality to merge and split word-level transcription segments. Buzz stores transcription timestamps in milliseconds, while `stable_whisper` expects timestamps in seconds.

Previously, timestamps were converted using `/100` when passing data to `stable_whisper` and `*100` when converting the result back. Although this preserved the final subtitle timestamps due to the matching conversion factors, it caused the regrouping logic to operate on incorrect time values.

This mainly affected the `merge_by_gap` option. Since timestamps passed to `stable_whisper` were 10x larger than the actual values, normal short pauses between words appeared much longer than they actually were, causing segments that should have been merged to remain split.

## Changes Made

Updated timestamp conversions in `buzz/plugins/transcript_resizer/plugin.py`:

- Changed conversion from Buzz milliseconds to `stable_whisper` seconds:
  - `buzz_segment.start_time / 100` → `buzz_segment.start_time / 1000`
  - `buzz_segment.end_time / 100` → `buzz_segment.end_time / 1000`

- Changed conversion from `stable_whisper` seconds back to Buzz milliseconds:
  - `segment.start * 100` → `segment.start * 1000`
  - `segment.end * 100` → `segment.end * 1000`

## Why This Fixes the Issue

Before this change, a real pause of `0.15` seconds was interpreted as `1.5` seconds by `stable_whisper` because the timestamps were scaled incorrectly.

With the default `merge_by_gap=0.2`, the regroup logic considered the pause too large and failed to merge segments that should have remained together.

After this fix, timestamps are passed in the correct unit, allowing `merge_by_gap` to work according to the configured threshold and correctly merge short pauses between words.

## Testing

- Verified that timestamp conversions now correctly use milliseconds to seconds and seconds to milliseconds.
- Confirmed that the changes are limited to the transcript resizer timestamp handling logic.
- Verified that `merge_by_gap` receives timestamps in the expected unit for regrouping.