### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11.9"
+          python-version: "3.12"
 
       - name: Install Poetry Action
         uses: snok/install-poetry@v1.3.1


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.12,<3.13`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.12,<3.13` (using `3.12` where a concrete pin is needed).

- `.github/workflows/manual-build.yml`
  - `python-version: "3.11.9"` → `python-version: "3.12"`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.12,<3.13`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
