### PR TITLE
Complete missing Chinese translations for skip_already_transcribed pl…

### DIFF
--- a/buzz/locale/zh_CN/LC_MESSAGES/buzz.po
+++ b/buzz/locale/zh_CN/LC_MESSAGES/buzz.po
@@ -1805,7 +1805,7 @@ msgstr "检查现有结果文件"
 msgid ""
 "Skip if a .txt, .srt, or .vtt file matching the audio filename is found next "
 "to it"
-msgstr ""
+msgstr "如果音频文件旁边存在匹配的 .txt、.srt 或 .vtt 文件，则跳过"
 
 #: buzz/plugins/skip_already_transcribed/plugin.py
 msgid "Check in transcription database"
@@ -1815,7 +1815,7 @@ msgstr "在转录数据库中检查"
 msgid ""
 "Skip if this file has already been transcribed and the record exists in the "
 "database"
-msgstr ""
+msgstr "如果此文件已转录且数据库中存在记录，则跳过"
 
 #: buzz/plugins/ai_summary/plugin.py
 msgid "AI Summary"

--- a/buzz/locale/zh_TW/LC_MESSAGES/buzz.po
+++ b/buzz/locale/zh_TW/LC_MESSAGES/buzz.po
@@ -1806,7 +1806,7 @@ msgstr "檢查現有結果檔案"
 msgid ""
 "Skip if a .txt, .srt, or .vtt file matching the audio filename is found next "
 "to it"
-msgstr ""
+msgstr "如果音訊檔案旁邊存在相符的 .txt、.srt 或 .vtt 檔案，則跳過"
 
 #: buzz/plugins/skip_already_transcribed/plugin.py
 msgid "Check in transcription database"
@@ -1816,7 +1816,7 @@ msgstr "在轉錄資料庫中檢查"
 msgid ""
 "Skip if this file has already been transcribed and the record exists in the "
 "database"
-msgstr ""
+msgstr "如果此檔案已轉錄且資料庫中存在記錄，則跳過"
 
 #: buzz/plugins/ai_summary/plugin.py
 msgid "AI Summary"

--- a/readme/README.zh_CN.md
+++ b/readme/README.zh_CN.md
@@ -12,42 +12,96 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/chidiwilliams/buzz)
 [![Github all releases](https://img.shields.io/github/downloads/chidiwilliams/buzz/total.svg)](https://GitHub.com/chidiwilliams/buzz/releases/)
 
+![Buzz](https://raw.githubusercontent.com/chidiwilliams/buzz/refs/heads/main/buzz/assets/buzz-banner.jpg)
+
+## 功能特性
+
+- 转录音视频文件或 YouTube 链接
+- 麦克风实时音频转录
+  - 演示窗口，方便活动和演讲时使用
+- 转录前语音分离，提升嘈杂音频的准确性
+- 转录媒体中的说话人识别
+- 支持多种 Whisper 后端
+  - 支持 Nvidia GPU 的 CUDA 加速
+  - 支持 Mac Apple Silicon
+  - 支持 Whisper.cpp 在大多数 GPU（含集成显卡）上的 Vulkan 加速
+- 通过 Huggingface 支持多种 Transformer 模型系列
+- 导出转录文本为 TXT、SRT 和 VTT 格式
+- 高级转录查看器，支持搜索、播放控制和速度调节
+- 高效导航的键盘快捷键
+- 监听文件夹，自动转录新文件
+- 支持脚本和自动化的命令行界面
+- 插件系统，含 AI 摘要生成和自动转录调整等插件
+
 ## 安装
 
-**PyPI**:
+### macOS
+
+从 [SourceForge](https://sourceforge.net/projects/buzz-captions/files/) 下载 `.dmg` 文件。
+
+### Windows
+
+从 [SourceForge](https://sourceforge.net/projects/buzz-captions/files/) 下载安装文件。
+
+应用程序未获得签名，安装时会收到警告弹窗。选择 `更多信息` -> `仍然运行`。
+
+### Linux
+
+Buzz 可通过 [Flatpak](https://flathub.org/apps/io.github.chidiwilliams.Buzz) 或 [Snap](https://snapcraft.io/buzz) 安装。
+
+安装 Flatpak：
+```shell
+flatpak install flathub io.github.chidiwilliams.Buzz
+```
+
+[![Download on Flathub](https://flathub.org/api/badge?svg&locale=en)](https://flathub.org/en/apps/io.github.chidiwilliams.Buzz)
+
+安装 Snap：
+```shell
+sudo apt-get install libportaudio2 libcanberra-gtk-module libcanberra-gtk3-module
+sudo snap install buzz
+```
+
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/buzz)
+
+### PyPI
 
 安装 [ffmpeg](https://www.ffmpeg.org/download.html)
 
-安装 Buzz
+确保使用 Python 3.12 环境。
+
+安装 Buzz：
 
 ```shell
 pip install buzz-captions
 python -m buzz
 ```
 
-**macOS**:
+**PyPI 版本的 GPU 支持**
 
-使用 [brew utility](https://brew.sh/) 安装
+如需在 Windows 上为 Nvidia GPU 启用 GPU 支持，请为 PyPI 安装版本确保 [torch](https://pytorch.org/get-started/locally/) 的 CUDA 支持：
 
-```shell
-brew install --cask buzz
+```
+pip3 install -U torch==2.8.0+cu129 torchaudio==2.8.0+cu129 --index-url https://download.pytorch.org/whl/cu129
+pip3 install nvidia-cublas-cu12==12.9.1.4 nvidia-cuda-cupti-cu12==12.9.79 nvidia-cuda-runtime-cu12==12.9.79 --extra-index-url https://pypi.ngc.nvidia.com
 ```
 
-或下载并运行在 [Releases ](https://github.com/chidiwilliams/buzz/releases/latest) 页面中的 `.dmg` 文件 .
+### 最新开发版本
 
-**Windows**:
+有关如何获取具有最新功能和错误修复的最新开发版本，请查阅 [FAQ](https://chidiwilliams.github.io/buzz/docs/faq#9-where-can-i-get-latest-development-version)。
 
-下载并运行在 [Releases ](https://github.com/chidiwilliams/buzz/releases/latest) 页面中的 `.exe` 文件。
+### 支持 Buzz
 
-应用程序未获得签名，当安装时会收到警告弹窗。 选择 `更多信息` -> `仍然运行`.
+您可以通过给仓库点亮 🌟 Star 并分享给朋友来支持 Buzz。
 
-**Linux**:
+### 截图
 
-```shell
-sudo apt-get install libportaudio2 libcanberra-gtk-module libcanberra-gtk3-module
-sudo snap install buzz
-```
-
-### 最新开发者版本
-
-有关如何获取具有最新功能和错误修复的最新开发版本的信息，请查阅 [FAQ](https://chidiwilliams.github.io/buzz/docs/faq#9-where-can-i-get-latest-development-version).
+<div style="display: flex; flex-wrap: wrap;">
+    <img alt="导入文件" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-1-import.png" style="max-width: 18%; margin-right: 1%;" />
+    <img alt="主界面" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-2-main_screen.png" style="max-width: 18%; margin-right: 1%; height:auto;" />
+    <img alt="偏好设置" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-3-preferences.png" style="max-width: 18%; margin-right: 1%; height:auto;" />
+    <img alt="模型偏好" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-3.2-model-preferences.png" style="max-width: 18%; margin-right: 1%; height:auto;" />
+    <img alt="转录文本" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-4-transcript.png" style="max-width: 18%; margin-right: 1%; height:auto;" />
+    <img alt="实时录音" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-5-live_recording.png" style="max-width: 18%; margin-right: 1%; height:auto;" />
+    <img alt="调整大小" src="https://github.com/chidiwilliams/buzz/raw/main/share/screenshots/buzz-6-resize.png" style="max-width: 18%;" />
+</div>


### PR DESCRIPTION

## Changes

- Fill in 2 untranslated strings in `zh_CN` and `zh_TW` locales for the `skip_already_transcribed` plugin
- Update `README.zh_CN.md` to sync with the latest English README (added Features section, updated install links, added Screenshots)

## Call for translators

The following2 strings are currently untranslated in all other languages. Native speakers are welcome to con

- `"Skip if a .txt, .srt, or .vtt file matching the audio filename is found next to it"`
- `"Skip if this file has already been transcribed and the record exists in the database"`

Affected locales: `ca_ES`,  `it_IT`, `ja_JP`, `lv_LV`,`nl`, `pl_PL`, `pt_BR`, `ru`, `uk_UA`
