### PR TITLE
fix: include torchcodec metadata in PyInstaller Windows build

### DIFF
--- a/Buzz.spec
+++ b/Buzz.spec
@@ -35,6 +35,10 @@ datas += copy_metadata("treetable")
 datas += copy_metadata("soundfile")
 datas += copy_metadata("dora-search")
 datas += copy_metadata("lhotse")
+# transformers 5.x audio_utils calls importlib.metadata.version("torchcodec")
+# at import time when AutoProcessor loads; without this the frozen Windows
+# build crashes on startup with PackageNotFoundError.
+datas += copy_metadata("torchcodec")
 
 # Allow transformers package to load __init__.py file dynamically:
 # https://github.com/chidiwilliams/buzz/issues/272


### PR DESCRIPTION

> **⚠️ AI-assisted change — please review thoroughly before merging.**  
> This fix was drafted with AI assistance. Please verify the packaging change, the diagnosis, and that a rebuilt Windows executable actually starts cleanly. Do not merge on trust of the agent alone.

## What happened

After installing a recent Windows build (post transformers 5.x), Buzz crashed immediately on startup — before the UI appeared — with:

```txt
importlib.metadata.PackageNotFoundError: No package metadata was found for torchcodec
ModuleNotFoundError: Could not import module 'AutoProcessor'.
```

The useful part of the traceback was:

1. `main` → `buzz.transformers_whisper` imports `AutoProcessor` from `transformers`
2. That pulls in `transformers.audio_utils`
3. At import time, transformers checks `importlib.metadata.version("torchcodec")`
4. In the frozen PyInstaller app that call fails because the **torchcodec distribution metadata** was never bundled

So this was not a missing user dependency or a broken install on my machine: the app could see the `torchcodec` module (enough for `is_torchcodec_available()` to return true), but PyInstaller had not copied the package metadata that `importlib.metadata` needs.

## Why this broke now

`torchcodec` is already a dependency in `pyproject.toml`, and `Buzz.spec` already uses `copy_metadata(...)` for many packages (`torch`, `tqdm`, etc.). After the transformers 5.x update, startup now hits that metadata lookup unconditionally via the `AutoProcessor` import path. `Buzz.spec` was never updated to include `copy_metadata("torchcodec")`, so the Windows executable started crashing on launch.

## Fix

In `Buzz.spec`, add:

```python
datas += copy_metadata("torchcodec")
```

Same pattern as the existing metadata includes. No application logic change.

## How to verify

- [ ] Rebuild the Windows app with PyInstaller / the normal release pipeline
- [ ] Launch the rebuilt `Buzz.exe` — it should open without the `torchcodec` / `AutoProcessor` traceback
- [ ] Optionally run a HuggingFace / transformers transcription once, to confirm that path still works after packaging

## Notes / caveats for reviewers

- I could not fully validate this with a local Windows release rebuild in this change; the diagnosis is from the startup traceback + `Buzz.spec` / transformers import behavior.
- If the rebuild surfaces a similar `PackageNotFoundError` for another package, it likely needs the same `copy_metadata(...)` treatment.
