### PR TITLE
Add structured speaker editing, view, and DOCX export

### DIFF
--- a/buzz/db/dao/transcription_segment_dao.py
+++ b/buzz/db/dao/transcription_segment_dao.py
@@ -51,3 +51,17 @@ class TranscriptionSegmentDAO(DAO[TranscriptionSegment]):
         query.bindValue(":translation", translation)
         if not query.exec():
             raise Exception(query.lastError().text())
+
+    def update_segment_speaker(self, segment_id: int, speaker: str):
+        query = self._create_query()
+        query.prepare(
+            """
+            UPDATE transcription_segment
+            SET speaker = :speaker
+            WHERE id = :id
+        """
+        )
+        query.bindValue(":id", segment_id)
+        query.bindValue(":speaker", speaker.strip())
+        if not query.exec():
+            raise Exception(query.lastError().text())

--- a/buzz/db/entity/transcription_segment.py
+++ b/buzz/db/entity/transcription_segment.py
@@ -10,4 +10,5 @@ class TranscriptionSegment(Entity):
     text: str
     translation: str
     transcription_id: str
+    speaker: str = ""
     id: int = -1

--- a/buzz/db/helpers.py
+++ b/buzz/db/helpers.py
@@ -53,8 +53,11 @@ def copy_transcriptions_from_json_to_sqlite(conn: Connection):
             for segment in task.segments:
                 cursor.execute(
                     """
-                    INSERT INTO transcription_segment (end_time, start_time, text, translation, transcription_id)
-                    VALUES (?, ?, ?, ?, ?);
+                    INSERT INTO transcription_segment (
+                        end_time, start_time, text, translation,
+                        transcription_id, speaker
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?);
                     """,
                     (
                         segment.end,
@@ -62,6 +65,7 @@ def copy_transcriptions_from_json_to_sqlite(conn: Connection):
                         segment.text,
                         segment.translation,
                         transcription_id,
+                        getattr(segment, "speaker", ""),
                     ),
                 )
         # os.remove(cache.tasks_list_file_path)

--- a/buzz/db/service/transcription_service.py
+++ b/buzz/db/service/transcription_service.py
@@ -44,6 +44,7 @@ class TranscriptionService:
                     text=segment.text,
                     translation='',
                     transcription_id=str(id),
+                    speaker=segment.speaker,
                 )
             )
 
@@ -69,6 +70,7 @@ class TranscriptionService:
                     text=segment.text,
                     translation='',
                     transcription_id=str(id),
+                    speaker=segment.speaker,
                 )
             )
 
@@ -88,6 +90,7 @@ class TranscriptionService:
                     text=segment.text,
                     translation='',
                     transcription_id=str(id),
+                    speaker=segment.speaker,
                 )
             )
 
@@ -96,3 +99,8 @@ class TranscriptionService:
 
     def update_segment_translation(self, segment_id: int, translation: str):
         return self.transcription_segment_dao.update_segment_translation(segment_id, translation)
+
+    def update_segment_speaker(self, segment_id: int, speaker: str):
+        return self.transcription_segment_dao.update_segment_speaker(
+            segment_id, speaker
+        )

--- a/buzz/locale/ca_ES/LC_MESSAGES/buzz.po
+++ b/buzz/locale/ca_ES/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: buzz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2025-10-17 07:59+0200\n"
 "Last-Translator: Éric Duarte <contacto@ericdq.com>\n"
 "Language-Team: Catalan <jmas@softcatala.org>\n"
@@ -918,12 +918,26 @@ msgid "Queue"
 msgstr "Cua"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Sense assignar"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Trieu un parlant identificat o escriviu el nom d'un parlant nou."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Inicia"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Finalitza"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Parlant"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -937,6 +951,30 @@ msgstr "Text"
 msgid "Translation"
 msgstr "Traducció"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Feu doble clic per editar. Seleccioneu diverses files i feu clic dret per "
+"assignar parlants."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Assigna un parlant"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Parlant nou…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Parlant nou"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Nom del parlant:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Veure"
@@ -944,6 +982,14 @@ msgstr "Veure"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Marqua de temps"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Parlants"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Parlant:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1045,6 +1091,14 @@ msgstr " de més de 100 coincidències"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " de "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Tots els parlants"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "No hi ha segments per a aquest parlant."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1238,12 +1292,28 @@ msgid "Cancelled"
 msgstr "Cancel·lat"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Parlants"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Desa el fitxer"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Fitxers de text"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Voleu incloure les marques de temps de cada intervenció?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Documents del Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "L'exportació ha fallat"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/da_DK/LC_MESSAGES/buzz.po
+++ b/buzz/locale/da_DK/LC_MESSAGES/buzz.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Ole Guldberg2 <xalt7x.service@gmail.com>\n"
 "Language-Team: \n"
@@ -913,12 +913,26 @@ msgid "Queue"
 msgstr "Kø"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Ikke tildelt"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Vælg en identificeret taler, eller skriv et nyt talernavn."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Start"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Slut"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Taler"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -932,6 +946,30 @@ msgstr "Tekst"
 msgid "Translation"
 msgstr "Oversættelse"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Dobbeltklik for at redigere. Vælg flere rækker og højreklik for at tildele "
+"talere."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Tildel taler"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Ny taler…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Ny taler"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Talernavn:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Vis"
@@ -939,6 +977,14 @@ msgstr "Vis"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Tidsstempler"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Talere"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Taler:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1040,6 +1086,14 @@ msgstr " af 100+ matches"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " af "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Alle talere"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Ingen segmenter for denne taler."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1230,12 +1284,28 @@ msgid "Cancelled"
 msgstr "Annulleret"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Talere"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Gem fil"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Tekst filer"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Medtag tidsstempler for hver talertur?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word-dokumenter"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Eksport mislykkedes"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/de_DE/LC_MESSAGES/buzz.po
+++ b/buzz/locale/de_DE/LC_MESSAGES/buzz.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2025-03-05 14:41+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -919,12 +919,28 @@ msgid "Queue"
 msgstr "Warteschlange"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Nicht zugewiesen"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr ""
+"Wählen Sie einen erkannten Sprecher oder geben Sie einen neuen Sprechernamen "
+"ein."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Start"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Ende"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Sprecher"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -938,6 +954,30 @@ msgstr "Text"
 msgid "Translation"
 msgstr "Übersetzung"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Zum Bearbeiten doppelklicken. Mehrere Zeilen auswählen und rechtsklicken, um "
+"Sprecher zuzuweisen."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Sprecher zuweisen"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Neuer Sprecher…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Neuer Sprecher"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Sprechername:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Anzeigen"
@@ -945,6 +985,14 @@ msgstr "Anzeigen"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Zeitstempel"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Sprecher"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Sprecher:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1049,6 +1097,14 @@ msgstr " von 100+ Treffern"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " von "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Alle Sprecher"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Keine Segmente für diesen Sprecher."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1241,12 +1297,28 @@ msgid "Cancelled"
 msgstr "Abgebrochen"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Sprecher"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Datei speichern"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Textdateien"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Zeitstempel für jeden Sprecherwechsel einfügen?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word-Dokumente"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Export fehlgeschlagen"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/en_US/LC_MESSAGES/buzz.po
+++ b/buzz/locale/en_US/LC_MESSAGES/buzz.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -878,11 +878,25 @@ msgid "Queue"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
@@ -897,12 +911,42 @@ msgstr ""
 msgid "Translation"
 msgstr ""
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr ""
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
@@ -1002,6 +1046,14 @@ msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
@@ -1183,11 +1235,27 @@ msgid "Cancelled"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr ""
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr ""
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
 msgstr ""
 
 #: buzz/widgets/model_download_progress_dialog.py

--- a/buzz/locale/es_ES/LC_MESSAGES/buzz.po
+++ b/buzz/locale/es_ES/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2025-09-08 12:43+0200\n"
 "Last-Translator: Éric Duarte <contacto@ericdq.com>\n"
 "Language-Team: \n"
@@ -954,12 +954,27 @@ msgid "Queue"
 msgstr "Cola"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Sin asignar"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr ""
+"Elija un hablante identificado o escriba el nombre de un nuevo hablante."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Inicio"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Fin"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Hablante"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -974,6 +989,30 @@ msgstr "Texto"
 msgid "Translation"
 msgstr "Traducción"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Haga doble clic para editar. Seleccione varias filas y haga clic derecho "
+"para asignar hablantes."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Asignar hablante"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Nuevo hablante…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Nuevo hablante"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Nombre del hablante:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Ver"
@@ -981,6 +1020,14 @@ msgstr "Ver"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Marcas de tiempo"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Hablantes"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Hablante:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1086,6 +1133,14 @@ msgstr " de 100+ coincidencias"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " de "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Todos los hablantes"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "No hay segmentos para este hablante."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1277,6 +1332,10 @@ msgstr "Cancelando..."
 msgid "Cancelled"
 msgstr "Cancelado"
 
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Hablantes"
+
 # automatic translation
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
@@ -1285,6 +1344,19 @@ msgstr "Guardar archivo"
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Archivos de texto"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "¿Incluir marcas de tiempo en cada intervención?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Documentos de Word"
+
+# automatic translation
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "La exportación ha fallado"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/it_IT/LC_MESSAGES/buzz.po
+++ b/buzz/locale/it_IT/LC_MESSAGES/buzz.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: buzz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2026-04-12 21:42+0200\n"
 "Language-Team: (Italiano) Albano Battistella <albanobattistella@gmail.com>\n"
 "Language: it_IT\n"
@@ -918,12 +918,26 @@ msgid "Queue"
 msgstr "Coda"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Non assegnato"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Scegli un parlante identificato o digita il nome di un nuovo parlante."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Inizio"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Fine"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Parlante"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -937,6 +951,30 @@ msgstr "Testo"
 msgid "Translation"
 msgstr "Traduzione"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Fai doppio clic per modificare. Seleziona più righe e fai clic con il tasto "
+"destro per assegnare i parlanti."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Assegna parlante"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Nuovo parlante…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Nuovo parlante"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Nome del parlante:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Visualizza"
@@ -944,6 +982,14 @@ msgstr "Visualizza"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Timestamp"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Parlanti"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Parlante:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1049,6 +1095,14 @@ msgstr " di oltre 100 corrispondenze"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " di "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Tutti i parlanti"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Nessun segmento per questo parlante."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1242,12 +1296,28 @@ msgid "Cancelled"
 msgstr "Annullato"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Parlanti"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Salva file"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "File di testo"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Includere i timestamp per ogni turno di parola?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Documenti Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Esportazione non riuscita"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/ja_JP/LC_MESSAGES/buzz.po
+++ b/buzz/locale/ja_JP/LC_MESSAGES/buzz.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: nunawa <71294849+nunawa@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -907,12 +907,26 @@ msgid "Queue"
 msgstr "キュー"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "未割り当て"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "認識された話者を選択するか、新しい話者名を入力してください。"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "開始"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "終了"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "話者"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -926,6 +940,30 @@ msgstr "テキスト"
 msgid "Translation"
 msgstr "翻訳"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"ダブルクリックで編集します。複数の行を選択して右クリックすると話者を割り当て"
+"られます。"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "話者を割り当てる"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "新しい話者…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "新しい話者"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "話者名:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "表示"
@@ -933,6 +971,14 @@ msgstr "表示"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "タイムスタンプ"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "話者"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "話者:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1034,6 +1080,14 @@ msgstr " / 100件以上一致"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " / "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "すべての話者"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "この話者のセグメントはありません。"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1216,12 +1270,28 @@ msgid "Cancelled"
 msgstr "キャンセル済み"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – 話者"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "ファイルを保存"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "テキストファイル"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "話者の発話ごとにタイムスタンプを含めますか?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word 文書"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "出力に失敗しました"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/lv_LV/LC_MESSAGES/buzz.po
+++ b/buzz/locale/lv_LV/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2026-03-06 13:23+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -910,12 +910,26 @@ msgid "Queue"
 msgstr "Rinda"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Nav piešķirts"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Izvēlieties noteiktu runātāju vai ierakstiet jauna runātāja vārdu."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Sākums"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Beigas"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Runātājs"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -929,6 +943,30 @@ msgstr "Teksts"
 msgid "Translation"
 msgstr "Tulkojums"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Veiciet dubultklikšķi, lai rediģētu. Atlasiet vairākas rindas un "
+"noklikšķiniet ar peles labo taustiņu, lai piešķirtu runātājus."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Piešķirt runātāju"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Jauns runātājs…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Jauns runātājs"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Runātāja vārds:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Skats"
@@ -936,6 +974,14 @@ msgstr "Skats"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Laiks"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Runātāji"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Runātājs:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1037,6 +1083,14 @@ msgstr " no 100+"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " no "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Visi runātāji"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Šim runātājam nav segmentu."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1223,12 +1277,28 @@ msgid "Cancelled"
 msgstr "Atcelts"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Runātāji"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Saglabāt failu"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Teksta faili"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Vai iekļaut laika atzīmes runātāju teikumiem?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word dokumenti"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Eksportēšana neizdevās"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/nl/LC_MESSAGES/buzz.po
+++ b/buzz/locale/nl/LC_MESSAGES/buzz.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2025-03-20 18:30+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -919,12 +919,26 @@ msgid "Queue"
 msgstr "Wachtrij"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Niet toegewezen"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Kies een geïdentificeerde spreker of typ een nieuwe sprekernaam."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Begin"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Einde"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Spreker"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -938,6 +952,30 @@ msgstr "Tekst"
 msgid "Translation"
 msgstr "Vertaling"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Dubbelklik om te bewerken. Selecteer meerdere rijen en klik met de "
+"rechtermuisknop om sprekers toe te wijzen."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Spreker toewijzen"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Nieuwe spreker…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Nieuwe spreker"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Sprekernaam:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Bekijken"
@@ -945,6 +983,14 @@ msgstr "Bekijken"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Tijdstippen"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Sprekers"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Spreker:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1046,6 +1092,14 @@ msgstr " van 100+ overeenkomsten"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " van "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Alle sprekers"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Geen segmenten voor deze spreker."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1237,12 +1291,28 @@ msgid "Cancelled"
 msgstr "Afgebroken"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Sprekers"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Bestand opslaan"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Tekstbestanden"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Tijdstippen voor elke spreekwisseling opnemen?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word-documenten"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Exporteren mislukt"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/pl_PL/LC_MESSAGES/buzz.po
+++ b/buzz/locale/pl_PL/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2024-03-17 20:50+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -916,12 +916,26 @@ msgid "Queue"
 msgstr "Kolejka"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Nieprzypisane"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Wybierz zidentyfikowanego mówcę lub wpisz nazwę nowego mówcy."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Rozpocznij"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Zakończ"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Mówca"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -935,6 +949,30 @@ msgstr "Tekst"
 msgid "Translation"
 msgstr "Tłumaczenie"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Kliknij dwukrotnie, aby edytować. Zaznacz wiele wierszy i kliknij prawym "
+"przyciskiem myszy, aby przypisać mówców."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Przypisz mówcę"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Nowy mówca…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Nowy mówca"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Nazwa mówcy:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Widok"
@@ -942,6 +980,14 @@ msgstr "Widok"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Znaczniki czasu"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Mówcy"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Mówca:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1043,6 +1089,14 @@ msgstr " z 100+ wyników"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " z "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Wszyscy mówcy"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Brak segmentów dla tego mówcy."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1235,12 +1289,28 @@ msgid "Cancelled"
 msgstr "Anulowano"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Mówcy"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Zapisz plik"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Pliki tekstowe"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Czy dołączyć znaczniki czasu dla każdej wypowiedzi?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Dokumenty Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Eksport nie powiódł się"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/pt_BR/LC_MESSAGES/buzz.po
+++ b/buzz/locale/pt_BR/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Buzz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2025-11-01 17:43-0300\n"
 "Last-Translator: Paulo Schopf <pschopf@gmail.com>\n"
 "Language-Team: none\n"
@@ -916,12 +916,26 @@ msgid "Queue"
 msgstr "Fila"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Não atribuído"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Escolha um falante identificado ou digite o nome de um novo falante."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Início"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Fim"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Falante"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -935,6 +949,30 @@ msgstr "Texto"
 msgid "Translation"
 msgstr "Tradução"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Clique duas vezes para editar. Selecione várias linhas e clique com o botão "
+"direito para atribuir falantes."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Atribuir Falante"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Novo Falante…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Novo Falante"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Nome do falante:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Visualizar"
@@ -942,6 +980,14 @@ msgstr "Visualizar"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Marcações de tempo"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Falantes"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Falante:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1043,6 +1089,14 @@ msgstr " de 100+ encontros"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " de "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Todos os falantes"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Nenhum segmento para este falante."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1233,12 +1287,28 @@ msgid "Cancelled"
 msgstr "Cancelado"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Falantes"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Salvar Arquivo"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Arquivos de texto"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Incluir marcações de tempo para cada fala?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Documentos do Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Falha na Exportação"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/ru/LC_MESSAGES/buzz.po
+++ b/buzz/locale/ru/LC_MESSAGES/buzz.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -914,12 +914,26 @@ msgid "Queue"
 msgstr "Очередь"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Не назначен"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Выберите определённого говорящего или введите новое имя."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Начало"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Конец"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Говорящий"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -933,6 +947,30 @@ msgstr "Текст"
 msgid "Translation"
 msgstr "Перевод"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Дважды щёлкните для редактирования. Выделите несколько строк и щёлкните "
+"правой кнопкой мыши, чтобы назначить говорящих."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Назначить говорящего"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Новый говорящий…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Новый говорящий"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Имя говорящего:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Вид"
@@ -940,6 +978,14 @@ msgstr "Вид"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Таймкоды"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Говорящие"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Говорящий:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1041,6 +1087,14 @@ msgstr " из 100+ совпадений"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " из "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Все говорящие"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Для этого говорящего нет сегментов."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1233,12 +1287,28 @@ msgid "Cancelled"
 msgstr "Отменено"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Говорящие"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Сохранить файл"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Текстовые файлы"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Включить таймкоды для каждой реплики?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Документы Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Не удалось экспортировать"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/uk_UA/LC_MESSAGES/buzz.po
+++ b/buzz/locale/uk_UA/LC_MESSAGES/buzz.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Yevhen Popok <xalt7x.service@gmail.com>\n"
 "Language-Team: \n"
@@ -912,12 +912,26 @@ msgid "Queue"
 msgstr "Черга"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Не призначено"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Виберіть визначеного мовця або введіть нове ім'я мовця."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "Початок"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "Кінець"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Мовець"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -931,6 +945,30 @@ msgstr "Текст"
 msgid "Translation"
 msgstr "Переклад"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Двічі клацніть, щоб редагувати. Виділіть кілька рядків і клацніть правою "
+"кнопкою миші, щоб призначити мовців."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Призначити мовця"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Новий мовець…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Новий мовець"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Ім'я мовця:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "Вигляд"
@@ -938,6 +976,14 @@ msgstr "Вигляд"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "Позначки часу"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Мовці"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "Мовець:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1039,6 +1085,14 @@ msgstr " з 100+ збігів"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr " з "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "Усі мовці"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "Для цього мовця немає сегментів."
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1229,12 +1283,28 @@ msgid "Cancelled"
 msgstr "Скасовано"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Мовці"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "Зберегти файл"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "Текстові файли"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Включити позначки часу для кожної репліки?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Документи Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Не вдалося експортувати"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/zh_CN/LC_MESSAGES/buzz.po
+++ b/buzz/locale/zh_CN/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2023-05-01 15:45+0800\n"
 "Last-Translator: \n"
 "Language-Team: lamb\n"
@@ -894,12 +894,26 @@ msgid "Queue"
 msgstr "队列"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "未指定"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "选择已识别的说话人或输入新的说话人名称。"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "开始"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "结束"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "说话人"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -913,6 +927,28 @@ msgstr "文本"
 msgid "Translation"
 msgstr "翻译"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr "双击可编辑。选择多行并右键单击可指定说话人。"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "指定说话人"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "新建说话人…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "新建说话人"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "说话人名称:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "查看"
@@ -920,6 +956,14 @@ msgstr "查看"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "时间戳"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "说话人"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "说话人:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1019,6 +1063,14 @@ msgstr "项，共100+个匹配项"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr "项，共"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "所有说话人"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "该说话人没有片段。"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1199,12 +1251,28 @@ msgid "Cancelled"
 msgstr "已取消"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – 说话人"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "保存文件"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "文本文件"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "是否为每次发言包含时间戳?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word 文档"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "导出失败"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/locale/zh_TW/LC_MESSAGES/buzz.po
+++ b/buzz/locale/zh_TW/LC_MESSAGES/buzz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 11:45+0300\n"
+"POT-Creation-Date: 2026-08-22 14:09+0300\n"
 "PO-Revision-Date: 2023-05-01 15:45+0800\n"
 "Last-Translator: \n"
 "Language-Team: Lamb\n"
@@ -895,12 +895,26 @@ msgid "Queue"
 msgstr "佇列"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "未指派"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "選擇已識別的說話者或輸入新的說話者名稱。"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "Start"
 msgstr "開始"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 msgid "End"
 msgstr "結束"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "說話者"
 
 #: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -914,6 +928,28 @@ msgstr "文字"
 msgid "Translation"
 msgstr "翻譯"
 
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr "雙擊以編輯。選取多列並按右鍵即可指派說話者。"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "指派說話者"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "新增說話者…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "新增說話者"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "說話者名稱:"
+
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "View"
 msgstr "檢視"
@@ -921,6 +957,14 @@ msgstr "檢視"
 #: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
 msgid "Timestamps"
 msgstr "時間戳記"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "說話者"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "Speaker:"
+msgstr "說話者:"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Export"
@@ -1020,6 +1064,14 @@ msgstr "，共 100 個以上符合項目"
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid " of "
 msgstr "，共 "
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "All speakers"
+msgstr "所有說話者"
+
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+msgid "No segments for this speaker."
+msgstr "此說話者沒有片段。"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "API Key Required"
@@ -1200,12 +1252,28 @@ msgid "Cancelled"
 msgstr "已取消"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – 說話者"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Save File"
 msgstr "儲存檔案"
 
 #: buzz/widgets/transcription_viewer/export_transcription_menu.py
 msgid "Text files"
 msgstr "文字檔案"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "是否為每次發言加入時間戳記?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Word 文件"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "匯出失敗"
 
 #: buzz/widgets/model_download_progress_dialog.py
 msgid "Downloading model"

--- a/buzz/plugins/export_docx/plugin.py
+++ b/buzz/plugins/export_docx/plugin.py
@@ -14,7 +14,6 @@ it working in the frozen app, where binary wheels such as ``python-docx``'s
 
 import logging
 import os
-from xml.sax.saxutils import escape
 
 from buzz.plugins.base import (
     BuzzPlugin,
@@ -28,37 +27,6 @@ from buzz.plugins.base import (
 logger = logging.getLogger(__name__)
 
 _ = plugin_gettext(__file__)
-
-# Same default gap (ms) used by the TXT exporter to split paragraphs.
-PARAGRAPH_SPLIT_TIME = 2000
-
-_CONTENT_TYPES_XML = (
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
-    '<Default Extension="rels" '
-    'ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
-    '<Default Extension="xml" ContentType="application/xml"/>'
-    '<Override PartName="/word/document.xml" '
-    'ContentType="application/vnd.openxmlformats-officedocument.'
-    'wordprocessingml.document.main+xml"/>'
-    "</Types>"
-)
-
-_RELS_XML = (
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
-    '<Relationship Id="rId1" '
-    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
-    'Target="word/document.xml"/>'
-    "</Relationships>"
-)
-
-_DOCUMENT_TEMPLATE = (
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
-    "<w:body>{body}<w:sectPr/></w:body>"
-    "</w:document>"
-)
 
 
 class ExportDocxPlugin(BuzzPlugin):
@@ -124,66 +92,14 @@ class ExportDocxPlugin(BuzzPlugin):
             context.log.error("Export to DOCX failed: %s", exc)
 
     def _write_docx(self, out_path, title, segments, include_timestamps):
-        import zipfile
+        from buzz.transcriber.docx_writer import write_plain_docx
 
-        from buzz.transcriber.file_transcriber import to_timestamp
-
-        paragraphs = [_heading_xml(title)]
-
-        if include_timestamps:
-            for segment in segments:
-                text = segment.text.strip()
-                if not text:
-                    continue
-                stamp = (
-                    f"[{to_timestamp(segment.start_time)} --> "
-                    f"{to_timestamp(segment.end_time)}]"
-                )
-                paragraphs.append(
-                    _paragraph_xml([(stamp + " ", True), (text, False)])
-                )
-        else:
-            # Group into paragraphs on long gaps, mirroring the TXT exporter.
-            current = []
-            previous_end = None
-            for segment in segments:
-                if (
-                    previous_end is not None
-                    and (segment.start_time - previous_end) >= PARAGRAPH_SPLIT_TIME
-                    and current
-                ):
-                    paragraphs.append(_paragraph_xml([(" ".join(current), False)]))
-                    current = []
-                text = segment.text.strip()
-                if text:
-                    current.append(text)
-                previous_end = segment.end_time
-            if current:
-                paragraphs.append(_paragraph_xml([(" ".join(current), False)]))
-
-        document_xml = _DOCUMENT_TEMPLATE.format(body="".join(paragraphs))
-
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as docx:
-            docx.writestr("[Content_Types].xml", _CONTENT_TYPES_XML)
-            docx.writestr("_rels/.rels", _RELS_XML)
-            docx.writestr("word/document.xml", document_xml)
-
-
-def _run_xml(text, bold):
-    props = "<w:rPr><w:b/></w:rPr>" if bold else ""
-    return f'<w:r>{props}<w:t xml:space="preserve">{escape(text)}</w:t></w:r>'
-
-
-def _paragraph_xml(runs):
-    return "<w:p>" + "".join(_run_xml(text, bold) for text, bold in runs) + "</w:p>"
-
-
-def _heading_xml(title):
-    return (
-        '<w:p><w:pPr><w:spacing w:after="200"/></w:pPr>'
-        '<w:r><w:rPr><w:b/><w:sz w:val="36"/><w:szCs w:val="36"/></w:rPr>'
-        f'<w:t xml:space="preserve">{escape(title)}</w:t></w:r></w:p>'
-    )
+        write_plain_docx(
+            out_path,
+            title,
+            segments,
+            include_timestamps,
+        )
 
 
 def _coerce_bool(value) -> bool:

--- a/buzz/schema.sql
+++ b/buzz/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE transcription_segment (
     text TEXT NOT NULL,
     translation TEXT DEFAULT '',
     transcription_id TEXT,
+    speaker TEXT DEFAULT '',
     FOREIGN KEY (transcription_id) REFERENCES transcription(id) ON DELETE CASCADE
 );
 CREATE INDEX idx_transcription_id ON transcription_segment(transcription_id);

--- a/buzz/speaker_transcript.py
+++ b/buzz/speaker_transcript.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+
+SPEAKER_COLORS = (
+    "#1976D2",
+    "#C62828",
+    "#2E7D32",
+    "#6A1B9A",
+    "#EF6C00",
+    "#00838F",
+    "#AD1457",
+    "#5D4037",
+    "#455A64",
+    "#558B2F",
+    "#283593",
+    "#9E6C00",
+)
+
+
+@dataclass
+class SpeakerGroup:
+    speaker: str
+    text: str
+    start_time: int
+    end_time: int
+
+
+def group_speaker_segments(
+    segments,
+    paragraph_split_time: int = 2000,
+) -> tuple[list[SpeakerGroup], list[str]]:
+    """Group adjacent segments exactly as the Speakers view displays them."""
+    groups: list[SpeakerGroup] = []
+    speaker_order: list[str] = []
+
+    for segment in segments:
+        speaker = (segment.speaker or "").strip()
+        text = (segment.text or "").strip()
+        if speaker and speaker not in speaker_order:
+            speaker_order.append(speaker)
+
+        if groups and groups[-1].speaker == speaker:
+            if text:
+                separator = (
+                    "\n"
+                    if segment.start_time - groups[-1].end_time
+                    >= paragraph_split_time
+                    else " "
+                )
+                groups[-1].text += separator + text
+            groups[-1].end_time = segment.end_time
+        else:
+            groups.append(
+                SpeakerGroup(
+                    speaker=speaker,
+                    text=text,
+                    start_time=segment.start_time,
+                    end_time=segment.end_time,
+                )
+            )
+
+    return groups, speaker_order

--- a/buzz/transcriber/docx_writer.py
+++ b/buzz/transcriber/docx_writer.py
@@ -1,0 +1,180 @@
+"""Dependency-free Microsoft Word writers used by Buzz exports."""
+
+import zipfile
+from xml.sax.saxutils import escape
+
+from buzz.speaker_transcript import SPEAKER_COLORS, group_speaker_segments
+from buzz.transcriber.file_transcriber import to_timestamp
+
+
+PARAGRAPH_SPLIT_TIME = 2000
+
+_CONTENT_TYPES_XML = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    '<Default Extension="rels" '
+    'ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    '<Default Extension="xml" ContentType="application/xml"/>'
+    '<Override PartName="/word/document.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.'
+    'wordprocessingml.document.main+xml"/>'
+    "</Types>"
+)
+
+_RELS_XML = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+    'Target="word/document.xml"/>'
+    "</Relationships>"
+)
+
+_DOCUMENT_TEMPLATE = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+    "<w:body>{body}<w:sectPr/></w:body>"
+    "</w:document>"
+)
+
+
+def write_plain_docx(
+    out_path: str,
+    title: str,
+    segments,
+    include_timestamps: bool,
+) -> None:
+    paragraphs = [_heading_xml(title)]
+
+    if include_timestamps:
+        for segment in segments:
+            text = (segment.text or "").strip()
+            if not text:
+                continue
+            stamp = (
+                f"[{to_timestamp(segment.start_time)} --> "
+                f"{to_timestamp(segment.end_time)}]"
+            )
+            paragraphs.append(
+                _paragraph_xml([(stamp + " ", True, None), (text, False, None)])
+            )
+    else:
+        current = []
+        previous_end = None
+        for segment in segments:
+            if (
+                previous_end is not None
+                and segment.start_time - previous_end >= PARAGRAPH_SPLIT_TIME
+                and current
+            ):
+                paragraphs.append(
+                    _paragraph_xml([(" ".join(current), False, None)])
+                )
+                current = []
+            text = (segment.text or "").strip()
+            if text:
+                current.append(text)
+            previous_end = segment.end_time
+        if current:
+            paragraphs.append(
+                _paragraph_xml([(" ".join(current), False, None)])
+            )
+
+    _write_docx_package(out_path, paragraphs)
+
+
+def write_speaker_docx(
+    out_path: str,
+    title: str,
+    segments,
+    include_timestamps: bool,
+    unassigned_label: str = "Unassigned",
+) -> None:
+    paragraphs = [_heading_xml(title)]
+    groups, speaker_order = group_speaker_segments(
+        segments,
+        paragraph_split_time=PARAGRAPH_SPLIT_TIME,
+    )
+    colors = {
+        speaker: SPEAKER_COLORS[index % len(SPEAKER_COLORS)].lstrip("#")
+        for index, speaker in enumerate(speaker_order)
+    }
+
+    for group in groups:
+        if not group.text:
+            continue
+        speaker_label = group.speaker or unassigned_label
+        label_runs = [
+            (
+                f"● {speaker_label}",
+                True,
+                colors.get(group.speaker, "757575"),
+            )
+        ]
+        if include_timestamps:
+            label_runs.append(
+                (
+                    "  " + _timestamp_text(group.start_time, group.end_time),
+                    False,
+                    "666666",
+                )
+            )
+        paragraphs.append(_paragraph_xml(label_runs, spacing_after=40))
+        paragraphs.append(
+            _paragraph_xml([(group.text, False, "000000")], spacing_after=220)
+        )
+
+    _write_docx_package(out_path, paragraphs)
+
+
+def _timestamp_text(start_time: int, end_time: int) -> str:
+    return f"[{to_timestamp(start_time)} – {to_timestamp(end_time)}]"
+
+
+def _run_xml(text: str, bold: bool, color: str | None) -> str:
+    properties = []
+    if bold:
+        properties.append("<w:b/>")
+    if color:
+        properties.append(f'<w:color w:val="{color.lstrip("#")}"/>')
+    run_properties = (
+        "<w:rPr>" + "".join(properties) + "</w:rPr>"
+        if properties
+        else ""
+    )
+    text_parts = text.split("\n")
+    content = "<w:br/>".join(
+        f'<w:t xml:space="preserve">{escape(part)}</w:t>'
+        for part in text_parts
+    )
+    return f"<w:r>{run_properties}{content}</w:r>"
+
+
+def _paragraph_xml(runs, spacing_after: int | None = None) -> str:
+    paragraph_properties = (
+        f'<w:pPr><w:spacing w:after="{spacing_after}"/></w:pPr>'
+        if spacing_after is not None
+        else ""
+    )
+    return (
+        "<w:p>"
+        + paragraph_properties
+        + "".join(_run_xml(text, bold, color) for text, bold, color in runs)
+        + "</w:p>"
+    )
+
+
+def _heading_xml(title: str) -> str:
+    return (
+        '<w:p><w:pPr><w:spacing w:after="200"/></w:pPr>'
+        '<w:r><w:rPr><w:b/><w:sz w:val="36"/><w:szCs w:val="36"/></w:rPr>'
+        f'<w:t xml:space="preserve">{escape(title)}</w:t></w:r></w:p>'
+    )
+
+
+def _write_docx_package(out_path: str, paragraphs: list[str]) -> None:
+    document_xml = _DOCUMENT_TEMPLATE.format(body="".join(paragraphs))
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as docx:
+        docx.writestr("[Content_Types].xml", _CONTENT_TYPES_XML)
+        docx.writestr("_rels/.rels", _RELS_XML)
+        docx.writestr("word/document.xml", document_xml)

--- a/buzz/transcriber/file_transcriber.py
+++ b/buzz/transcriber/file_transcriber.py
@@ -196,6 +196,11 @@ def write_output(
     )
 
     with open(os.fsencode(path), "w", encoding="utf-8") as file:
+        def segment_content(segment):
+            content = getattr(segment, segment_key).strip()
+            speaker = getattr(segment, "speaker", "").strip()
+            return f"{speaker}: {content}" if speaker else content
+
         if output_format == OutputFormat.TXT:
             combined_text = ""
             previous_end_time = None
@@ -205,7 +210,7 @@ def write_output(
             for segment in segments:
                 if previous_end_time is not None and (segment.start - previous_end_time) >= paragraph_split_time:
                     combined_text += "\n\n"
-                combined_text += getattr(segment, segment_key).strip() + " "
+                combined_text += segment_content(segment) + " "
                 previous_end_time = segment.end
 
             file.write(combined_text)
@@ -216,7 +221,7 @@ def write_output(
                 file.write(
                     f"{to_timestamp(segment.start)} --> {to_timestamp(segment.end)}\n"
                 )
-                file.write(f"{getattr(segment, segment_key)}\n\n")
+                file.write(f"{segment_content(segment)}\n\n")
 
         elif output_format == OutputFormat.SRT:
             for i, segment in enumerate(segments):
@@ -224,7 +229,7 @@ def write_output(
                 file.write(
                     f'{to_timestamp(segment.start, ms_separator=",")} --> {to_timestamp(segment.end, ms_separator=",")}\n'
                 )
-                file.write(f"{getattr(segment, segment_key)}\n\n")
+                file.write(f"{segment_content(segment)}\n\n")
 
     logging.debug("Written transcription output")
 

--- a/buzz/transcriber/transcriber.py
+++ b/buzz/transcriber/transcriber.py
@@ -33,6 +33,7 @@ class Segment:
     end: int  # end time in ms
     text: str
     translation: str = ""
+    speaker: str = ""
 
 
 LANGUAGES = {

--- a/buzz/widgets/transcription_viewer/export_transcription_menu.py
+++ b/buzz/widgets/transcription_viewer/export_transcription_menu.py
@@ -1,12 +1,14 @@
 import logging
+import os
 from PyQt6.QtGui import QAction
 from PyQt6.QtCore import pyqtSignal
-from PyQt6.QtWidgets import QWidget, QMenu, QFileDialog
+from PyQt6.QtWidgets import QWidget, QMenu, QFileDialog, QMessageBox
 
 from buzz.db.entity.transcription import Transcription
 from buzz.db.service.transcription_service import TranscriptionService
 from buzz.locale import _
 from buzz.transcriber.file_transcriber import write_output
+from buzz.transcriber.docx_writer import write_speaker_docx
 from buzz.transcriber.transcriber import (
     OutputFormat,
     Segment,
@@ -43,6 +45,15 @@ class ExportTranscriptionMenu(QMenu):
             action.setVisible(has_translation)
         actions = self.text_actions + self.translation_actions
         self.addActions(actions)
+
+        self.addSeparator()
+        self.speaker_docx_action = QAction(
+            text=_("DOCX – Speakers"),
+            parent=self,
+        )
+        self.addAction(self.speaker_docx_action)
+        self.aboutToShow.connect(self._refresh_speaker_docx_action)
+        self._refresh_speaker_docx_action()
         self.triggered.connect(self.on_menu_triggered)
 
     @staticmethod
@@ -59,12 +70,17 @@ class ExportTranscriptionMenu(QMenu):
             action.setVisible(True)
 
     def on_menu_triggered(self, action: QAction):
+        if action == self.speaker_docx_action:
+            self.export_speakers_docx()
+            return
+
         segments = [
             Segment(
                 start=segment.start_time,
                 end=segment.end_time,
                 text=segment.text,
-                translation=segment.translation)
+                translation=segment.translation,
+                speaker=segment.speaker)
             for segment in self.transcription_service.get_transcription_segments(
                 transcription_id=self.transcription.id_as_uuid
             )
@@ -93,3 +109,70 @@ class ExportTranscriptionMenu(QMenu):
             output_format=output_format,
             segment_key=segment_key
         )
+
+    def _refresh_speaker_docx_action(self):
+        segments = self.transcription_service.get_transcription_segments(
+            transcription_id=self.transcription.id_as_uuid
+        )
+        self.speaker_docx_action.setEnabled(
+            any((segment.speaker or "").strip() for segment in segments)
+        )
+
+    def export_speakers_docx(self):
+        segments = self.transcription_service.get_transcription_segments(
+            transcription_id=self.transcription.id_as_uuid
+        )
+        if not any((segment.speaker or "").strip() for segment in segments):
+            return
+
+        timestamp_choice = QMessageBox.question(
+            self,
+            _("DOCX – Speakers"),
+            _("Include timestamps for each speaker turn?"),
+            QMessageBox.StandardButton.Yes
+            | QMessageBox.StandardButton.No
+            | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.No,
+        )
+        if timestamp_choice == QMessageBox.StandardButton.Cancel:
+            return
+
+        source_path = self.transcription.file or "transcript"
+        source_directory = os.path.dirname(source_path)
+        source_stem = (
+            self.transcription.name
+            or os.path.splitext(os.path.basename(source_path))[0]
+            or "transcript"
+        )
+        default_path = os.path.join(
+            source_directory,
+            f"{source_stem}_speakers.docx",
+        )
+        output_file_path, _selected_filter = QFileDialog.getSaveFileName(
+            self,
+            _("Save File"),
+            default_path,
+            _("Word documents") + " (*.docx)",
+        )
+        if not output_file_path:
+            return
+        if not output_file_path.lower().endswith(".docx"):
+            output_file_path += ".docx"
+
+        try:
+            write_speaker_docx(
+                output_file_path,
+                source_stem,
+                segments,
+                include_timestamps=(
+                    timestamp_choice == QMessageBox.StandardButton.Yes
+                ),
+                unassigned_label=_("Unassigned"),
+            )
+        except Exception as exc:
+            logging.exception("Failed to export speaker DOCX")
+            QMessageBox.critical(
+                self,
+                _("Export Failed"),
+                str(exc),
+            )

--- a/buzz/widgets/transcription_viewer/speaker_identification_widget.py
+++ b/buzz/widgets/transcription_viewer/speaker_identification_widget.py
@@ -828,7 +828,8 @@ class SpeakerIdentificationWidget(QWidget):
                         segment = Segment(
                             start=previous_segment['start_time'],
                             end=previous_segment['end_time'],
-                            text=f"{previous_segment['speaker']}: {previous_segment['text']}"
+                            text=previous_segment['text'],
+                            speaker=previous_segment['speaker'],
                         )
                         segments.append(segment)
                     previous_segment = {
@@ -842,7 +843,8 @@ class SpeakerIdentificationWidget(QWidget):
                 segment = Segment(
                     start=previous_segment['start_time'],
                     end=previous_segment['end_time'],
-                    text=f"{previous_segment['speaker']}: {previous_segment['text']}"
+                    text=previous_segment['text'],
+                    speaker=previous_segment['speaker'],
                 )
                 segments.append(segment)
         else:
@@ -851,7 +853,8 @@ class SpeakerIdentificationWidget(QWidget):
                 segment = Segment(
                     start=entry['start_time'],
                     end=entry['end_time'],
-                    text=f"{speaker_name}: {entry['text']}"
+                    text=entry['text'],
+                    speaker=speaker_name,
                 )
                 segments.append(segment)
 

--- a/buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+++ b/buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
@@ -337,6 +337,7 @@ class TranscriptionSegmentModel(QSqlTableModel):
 
 class TranscriptionSegmentsEditorWidget(QTableView):
     PARENT_PADDINGS = 40
+    SPEAKER_COLUMN_WIDTH = 160
     segment_selected = pyqtSignal(QSqlRecord)
     timestamp_being_edited = pyqtSignal(int, int, int)  # Signal: (row, column, new_value_ms)
     speakers_changed = pyqtSignal(list)
@@ -363,6 +364,7 @@ class TranscriptionSegmentsEditorWidget(QTableView):
 
         self._last_highlighted_row = -1
         self._bulk_updating_speakers = False
+        self.has_speakers = False
         self.translator = translator
         self.translator.translation.connect(self.update_translation)
 
@@ -437,7 +439,7 @@ class TranscriptionSegmentsEditorWidget(QTableView):
 
         self.setColumnWidth(Column.START.value, 120)
         self.setColumnWidth(Column.END.value, 120)
-        self.setColumnWidth(Column.SPEAKER.value, 160)
+        self.setColumnWidth(Column.SPEAKER.value, self.SPEAKER_COLUMN_WIDTH)
 
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self._show_context_menu)
@@ -473,8 +475,9 @@ class TranscriptionSegmentsEditorWidget(QTableView):
         fixed_column_widths = (
             self.columnWidth(Column.START.value)
             + self.columnWidth(Column.END.value)
-            + self.columnWidth(Column.SPEAKER.value)
         )
+        if self.has_speakers:
+            fixed_column_widths += self.columnWidth(Column.SPEAKER.value)
         text_column_width = (
             int((self.parent().width() - self.PARENT_PADDINGS - fixed_column_widths) / text_column_count))
 
@@ -535,8 +538,26 @@ class TranscriptionSegmentsEditorWidget(QTableView):
         self._invalidate_segments_cache()
         speakers = self.speaker_names()
         self.speaker_delegate.set_speakers(speakers)
+        self.has_speakers = bool(speakers)
+        self._update_speaker_column_visibility()
         self.viewport().update()
         self.speakers_changed.emit(speakers)
+
+    def _update_speaker_column_visibility(self):
+        """Only show the speaker column when there are speakers to show."""
+        if self.has_speakers:
+            if not self.isColumnHidden(Column.SPEAKER.value):
+                return
+            self.showColumn(Column.SPEAKER.value)
+            self.setColumnWidth(Column.SPEAKER.value, self.SPEAKER_COLUMN_WIDTH)
+        elif not self.isColumnHidden(Column.SPEAKER.value):
+            self.hideColumn(Column.SPEAKER.value)
+        else:
+            return
+
+        # Give the text columns back the space the speaker column used
+        if self.parent() is not None:
+            self.resizeEvent(None)
 
     def selected_rows(self) -> list[int]:
         return sorted({index.row() for index in self.selectionModel().selectedRows()})

--- a/buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+++ b/buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
@@ -4,20 +4,41 @@ from dataclasses import dataclass
 from typing import Optional
 from uuid import UUID
 
-from PyQt6.QtCore import pyqtSignal, Qt, QModelIndex, QItemSelection, QEvent, QRegularExpression, QObject
-from PyQt6.QtGui import QRegularExpressionValidator
+from PyQt6.QtCore import (
+    pyqtSignal,
+    Qt,
+    QModelIndex,
+    QItemSelection,
+    QRegularExpression,
+    QSize,
+)
+from PyQt6.QtGui import (
+    QColor,
+    QFontMetrics,
+    QIcon,
+    QPainter,
+    QPixmap,
+    QRegularExpressionValidator,
+    QTextOption,
+)
 from PyQt6.QtSql import QSqlTableModel, QSqlRecord
-from PyQt6.QtGui import QFontMetrics, QTextOption
 from PyQt6.QtWidgets import (
+    QApplication,
     QWidget,
     QTableView,
     QStyledItemDelegate,
     QAbstractItemView,
     QTextEdit,
     QLineEdit,
+    QComboBox,
+    QInputDialog,
+    QMenu,
+    QStyle,
+    QStyleOptionViewItem,
 )
 
 from buzz.locale import _
+from buzz.speaker_transcript import SPEAKER_COLORS
 from buzz.translator import Translator
 from buzz.transcriber.file_transcriber import to_timestamp
 
@@ -29,6 +50,7 @@ class Column(enum.Enum):
     TEXT = enum.auto()
     TRANSLATION = enum.auto()
     TRANSCRIPTION_ID = enum.auto()
+    SPEAKER = enum.auto()
 
 
 @dataclass
@@ -228,6 +250,83 @@ class WordWrapDelegate(QStyledItemDelegate):
         model.setData(index, editor.toPlainText())
 
 
+class SpeakerDelegate(QStyledItemDelegate):
+    """Editable speaker selector with a visible, accessible color marker."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.speakers: list[str] = []
+        self.colors: dict[str, QColor] = {}
+
+    def set_speakers(self, speakers: list[str]):
+        self.speakers = speakers
+        self.colors = {
+            speaker: QColor(SPEAKER_COLORS[index % len(SPEAKER_COLORS)])
+            for index, speaker in enumerate(speakers)
+        }
+
+    def createEditor(self, parent, option, index):
+        editor = QComboBox(parent)
+        editor.setEditable(True)
+        editor.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        editor.addItem(_("Unassigned"), "")
+        for speaker in self.speakers:
+            editor.addItem(speaker, speaker)
+        editor.setToolTip(
+            _("Choose an identified speaker or type a new speaker name.")
+        )
+        return editor
+
+    def setEditorData(self, editor, index):
+        speaker = (index.data(Qt.ItemDataRole.EditRole) or "").strip()
+        speaker_index = editor.findData(speaker)
+        if speaker_index >= 0:
+            editor.setCurrentIndex(speaker_index)
+        else:
+            editor.setEditText(speaker)
+
+    def setModelData(self, editor, model, index):
+        current_index = editor.currentIndex()
+        if (
+            current_index >= 0
+            and editor.currentText() == editor.itemText(current_index)
+        ):
+            speaker = editor.itemData(current_index) or ""
+        else:
+            speaker = editor.currentText().strip()
+        model.setData(index, speaker)
+
+    def paint(self, painter, option, index):
+        speaker = (index.data(Qt.ItemDataRole.EditRole) or "").strip()
+        styled_option = QStyleOptionViewItem(option)
+        self.initStyleOption(styled_option, index)
+        styled_option.text = speaker or _("Unassigned")
+
+        if speaker:
+            pixmap = QPixmap(12, 12)
+            pixmap.fill(Qt.GlobalColor.transparent)
+            icon_painter = QPainter(pixmap)
+            icon_painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            icon_painter.setBrush(self.colors.get(speaker, QColor(SPEAKER_COLORS[0])))
+            icon_painter.setPen(Qt.PenStyle.NoPen)
+            icon_painter.drawEllipse(1, 1, 10, 10)
+            icon_painter.end()
+            styled_option.icon = QIcon(pixmap)
+            styled_option.decorationSize = QSize(12, 12)
+
+        style = (
+            styled_option.widget.style()
+            if styled_option.widget is not None
+            else QApplication.style()
+        )
+        style.drawControl(
+            QStyle.ControlElement.CE_ItemViewItem,
+            styled_option,
+            painter,
+            styled_option.widget,
+        )
+
+
 class TranscriptionSegmentModel(QSqlTableModel):
     def __init__(self, transcription_id: UUID):
         super().__init__()
@@ -240,6 +339,7 @@ class TranscriptionSegmentsEditorWidget(QTableView):
     PARENT_PADDINGS = 40
     segment_selected = pyqtSignal(QSqlRecord)
     timestamp_being_edited = pyqtSignal(int, int, int)  # Signal: (row, column, new_value_ms)
+    speakers_changed = pyqtSignal(list)
 
     _segments_cache: list[QSqlRecord] | None = None
 
@@ -262,6 +362,7 @@ class TranscriptionSegmentsEditorWidget(QTableView):
         super().__init__(parent)
 
         self._last_highlighted_row = -1
+        self._bulk_updating_speakers = False
         self.translator = translator
         self.translator.translation.connect(self.update_translation)
 
@@ -273,10 +374,12 @@ class TranscriptionSegmentsEditorWidget(QTableView):
         timestamp_editor_delegate.timestamp_editing.connect(self.timestamp_being_edited.emit)
 
         word_wrap_delegate = WordWrapDelegate()
+        self.speaker_delegate = SpeakerDelegate(self)
 
         self.column_definitions: list[ColDef] = [
             ColDef("start", _("Start"), Column.START, delegate=timestamp_editor_delegate),
             ColDef("end", _("End"), Column.END, delegate=timestamp_editor_delegate),
+            ColDef("speaker", _("Speaker"), Column.SPEAKER, delegate=self.speaker_delegate),
             ColDef("text", _("Text"), Column.TEXT, delegate=word_wrap_delegate),
             ColDef("translation", _("Translation"), Column.TRANSLATION, delegate=word_wrap_delegate),
         ]
@@ -296,10 +399,20 @@ class TranscriptionSegmentsEditorWidget(QTableView):
                     definition.column.value, definition.delegate
                 )
 
+        model.setHeaderData(
+            Column.SPEAKER.value,
+            Qt.Orientation.Horizontal,
+            _(
+                "Double-click to edit. Select multiple rows and right-click "
+                "to assign speakers."
+            ),
+            Qt.ItemDataRole.ToolTipRole,
+        )
+
         self.setAlternatingRowColors(True)
         self.verticalHeader().hide()
         self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
-        self.setSelectionMode(QTableView.SelectionMode.SingleSelection)
+        self.setSelectionMode(QTableView.SelectionMode.ExtendedSelection)
         self.setEditTriggers(
             QAbstractItemView.EditTrigger.EditKeyPressed |
             QAbstractItemView.EditTrigger.DoubleClicked
@@ -308,17 +421,28 @@ class TranscriptionSegmentsEditorWidget(QTableView):
         model.select()
         model.rowsInserted.connect(self.init_row_height)
         model.dataChanged.connect(self._invalidate_segments_cache)
+        model.dataChanged.connect(self._on_model_data_changed)
         model.modelReset.connect(self._invalidate_segments_cache)
 
         self.has_translations = self.has_non_empty_translation()
 
         # Show start before end
         self.horizontalHeader().swapSections(1, 2)
+        self.horizontalHeader().moveSection(
+            self.horizontalHeader().visualIndex(Column.SPEAKER.value),
+            self.horizontalHeader().visualIndex(Column.TEXT.value),
+        )
 
         self.init_row_height()
 
         self.setColumnWidth(Column.START.value, 120)
         self.setColumnWidth(Column.END.value, 120)
+        self.setColumnWidth(Column.SPEAKER.value, 160)
+
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._show_context_menu)
+
+        self._refresh_speakers()
 
         self.setWordWrap(True)
 
@@ -346,9 +470,13 @@ class TranscriptionSegmentsEditorWidget(QTableView):
 
         text_column_count = 2 if self.has_translations else 1
 
-        time_column_widths = self.columnWidth(Column.START.value) + self.columnWidth(Column.END.value)
+        fixed_column_widths = (
+            self.columnWidth(Column.START.value)
+            + self.columnWidth(Column.END.value)
+            + self.columnWidth(Column.SPEAKER.value)
+        )
         text_column_width = (
-            int((self.parent().width() - self.PARENT_PADDINGS - time_column_widths) / text_column_count))
+            int((self.parent().width() - self.PARENT_PADDINGS - fixed_column_widths) / text_column_count))
 
         self.setColumnWidth(Column.TEXT.value, text_column_width)
         self.setColumnWidth(Column.TRANSLATION.value, text_column_width)
@@ -385,6 +513,87 @@ class TranscriptionSegmentsEditorWidget(QTableView):
 
     def _invalidate_segments_cache(self):
         self._segments_cache = None
+
+    def _on_model_data_changed(self, top_left, bottom_right, roles=None):
+        if (
+            not self._bulk_updating_speakers
+            and
+            top_left.column() <= Column.SPEAKER.value
+            <= bottom_right.column()
+        ):
+            self._refresh_speakers()
+
+    def speaker_names(self) -> list[str]:
+        names = []
+        for segment in self.segments():
+            speaker = (segment.value("speaker") or "").strip()
+            if speaker and speaker not in names:
+                names.append(speaker)
+        return names
+
+    def _refresh_speakers(self):
+        self._invalidate_segments_cache()
+        speakers = self.speaker_names()
+        self.speaker_delegate.set_speakers(speakers)
+        self.viewport().update()
+        self.speakers_changed.emit(speakers)
+
+    def selected_rows(self) -> list[int]:
+        return sorted({index.row() for index in self.selectionModel().selectedRows()})
+
+    def assign_speaker_to_rows(self, rows: list[int], speaker: str):
+        speaker = speaker.strip()
+        model = self.model()
+        self._bulk_updating_speakers = True
+        try:
+            for row in sorted(set(rows)):
+                if 0 <= row < model.rowCount():
+                    model.setData(model.index(row, Column.SPEAKER.value), speaker)
+            model.submitAll()
+        finally:
+            self._bulk_updating_speakers = False
+        self._refresh_speakers()
+
+    def _show_context_menu(self, position):
+        index = self.indexAt(position)
+        if index.isValid() and index.row() not in self.selected_rows():
+            self.clearSelection()
+            self.selectRow(index.row())
+
+        rows = self.selected_rows()
+        menu = QMenu(self)
+        assign_menu = menu.addMenu(_("Assign Speaker"))
+        assign_menu.setEnabled(bool(rows))
+
+        unassigned_action = assign_menu.addAction(_("Unassigned"))
+        unassigned_action.triggered.connect(
+            lambda: self.assign_speaker_to_rows(rows, "")
+        )
+        if self.speaker_names():
+            assign_menu.addSeparator()
+        for speaker in self.speaker_names():
+            action = assign_menu.addAction(speaker)
+            action.triggered.connect(
+                lambda checked=False, name=speaker: self.assign_speaker_to_rows(
+                    rows, name
+                )
+            )
+        assign_menu.addSeparator()
+        new_speaker_action = assign_menu.addAction(_("New Speaker…"))
+        new_speaker_action.triggered.connect(
+            lambda: self._assign_new_speaker(rows)
+        )
+
+        menu.exec(self.viewport().mapToGlobal(position))
+
+    def _assign_new_speaker(self, rows: list[int]):
+        speaker, accepted = QInputDialog.getText(
+            self,
+            _("New Speaker"),
+            _("Speaker name:"),
+        )
+        if accepted and speaker.strip():
+            self.assign_speaker_to_rows(rows, speaker)
 
     def segments(self) -> list[QSqlRecord]:
         if self._segments_cache is not None:

--- a/buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+++ b/buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
@@ -16,6 +16,7 @@ class ViewMode(Enum):
     TEXT = "Text"
     TRANSLATION = "Translation"
     TIMESTAMPS = "Timestamps"
+    SPEAKERS = "Speakers"
 
 
 class TranscriptionViewModeToolButton(QToolButton):
@@ -26,6 +27,7 @@ class TranscriptionViewModeToolButton(QToolButton):
             shortcuts: Shortcuts,
             has_translation: bool,
             translation: pyqtSignal,
+            has_speakers: bool = False,
             parent: Optional[QWidget] = None
     ):
         super().__init__(parent)
@@ -59,8 +61,17 @@ class TranscriptionViewModeToolButton(QToolButton):
             lambda: self.view_mode_changed.emit(ViewMode.TIMESTAMPS),
         )
 
+        self.speakers_action = menu.addAction(
+            _("Speakers"),
+            lambda: self.view_mode_changed.emit(ViewMode.SPEAKERS),
+        )
+        self.speakers_action.setEnabled(has_speakers)
+
         self.setMenu(menu)
         self.clicked.connect(self.showMenu)
 
     def on_translation_available(self):
         self.translation_action.setVisible(True)
+
+    def on_speakers_changed(self, speakers: list[str]):
+        self.speakers_action.setEnabled(bool(speakers))

--- a/buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+++ b/buzz/widgets/transcription_viewer/transcription_viewer_widget.py
@@ -5,7 +5,7 @@ from typing import Optional
 from uuid import UUID
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal, QTimer
-from PyQt6.QtGui import QTextCursor
+from PyQt6.QtGui import QColor, QFont, QPalette, QTextCharFormat, QTextCursor
 from PyQt6.QtMultimedia import QMediaPlayer
 from PyQt6.QtSql import QSqlRecord
 from PyQt6.QtWidgets import (
@@ -30,6 +30,10 @@ from buzz.locale import _
 from buzz.db.entity.transcription import Transcription
 from buzz.db.service.transcription_service import TranscriptionService
 from buzz.paths import file_path_as_title
+from buzz.speaker_transcript import (
+    SPEAKER_COLORS,
+    group_speaker_segments,
+)
 from buzz.settings.shortcuts import Shortcuts
 from buzz.settings.shortcut import Shortcut
 from buzz.settings.settings import Settings
@@ -71,6 +75,7 @@ if not (platform.system() == "Darwin" and platform.machine() == "x86_64"):
 
 
 class TranscriptionViewerWidget(QWidget):
+    AUDIO_PLAYER_MAX_HEIGHT = 80
     resize_button_clicked = pyqtSignal()
     transcription: Transcription
     settings = Settings()
@@ -115,6 +120,7 @@ class TranscriptionViewerWidget(QWidget):
 
         self._setup_translation()
         self._setup_table_widget()
+        self._setup_speaker_filter()
         self._setup_media_players()
         self._setup_current_segment_frame()
         self._setup_toolbar()
@@ -141,6 +147,7 @@ class TranscriptionViewerWidget(QWidget):
         )
         self.has_translations = any(segment.translation.strip()
                                     for segment in segments)
+        self.has_speakers = any(segment.speaker.strip() for segment in segments)
 
     def _setup_translation(self):
         self.transcription_options_dialog = AdvancedSettingsDialog(
@@ -167,6 +174,26 @@ class TranscriptionViewerWidget(QWidget):
         self.table_widget.segment_selected.connect(self.on_segment_selected)
         self.table_widget.timestamp_being_edited.connect(
             self.on_timestamp_being_edited)
+        self.table_widget.speakers_changed.connect(self.on_speakers_changed)
+
+    def _setup_speaker_filter(self):
+        self.speaker_filter_frame = QFrame()
+        self.speaker_filter_frame.setFrameStyle(QFrame.Shape.StyledPanel)
+        self.speaker_filter_frame.setMaximumHeight(50)
+
+        speaker_filter_layout = QHBoxLayout(self.speaker_filter_frame)
+        speaker_filter_layout.setContentsMargins(10, 5, 10, 5)
+        speaker_filter_layout.addWidget(QLabel(_("Speaker:")))
+
+        self.speaker_filter_combo = QComboBox()
+        self.speaker_filter_combo.setMinimumWidth(180)
+        self.speaker_filter_combo.currentIndexChanged.connect(
+            self._render_speakers_view
+        )
+        speaker_filter_layout.addWidget(self.speaker_filter_combo)
+        speaker_filter_layout.addStretch()
+        self.speaker_filter_frame.hide()
+        self._refresh_speaker_filter()
 
     def _setup_media_players(self):
         self.text_display_box = TextDisplayBox(self)
@@ -176,6 +203,14 @@ class TranscriptionViewerWidget(QWidget):
 
         self.media_player_stack = QStackedWidget()
         self.media_player_stack.addWidget(self.audio_player)
+
+        # Audio only needs a compact controls row. Without an upper bound the
+        # splitter can let it consume most of the viewer and squeeze the
+        # transcript table down to a single row.
+        if not self.is_video:
+            self.media_player_stack.setMaximumHeight(
+                self.AUDIO_PLAYER_MAX_HEIGHT
+            )
 
         if self.is_video:
             self.video_player = VideoPlayer(file_path=self.transcription.file)
@@ -235,14 +270,15 @@ class TranscriptionViewerWidget(QWidget):
     def _setup_toolbar(self):
         toolbar = ToolBar(self)
 
-        view_mode_tool_button = TranscriptionViewModeToolButton(
+        self.view_mode_tool_button = TranscriptionViewModeToolButton(
             self.shortcuts,
             self.has_translations,
             self.translator.translation,
+            self.has_speakers,
         )
-        view_mode_tool_button.view_mode_changed.connect(
+        self.view_mode_tool_button.view_mode_changed.connect(
             self.on_view_mode_changed)
-        toolbar.addWidget(view_mode_tool_button)
+        toolbar.addWidget(self.view_mode_tool_button)
 
         export_tool_button = QToolButton()
         export_tool_button.setText(_("Export"))
@@ -315,6 +351,7 @@ class TranscriptionViewerWidget(QWidget):
         layout = self.layout()
 
         layout.addWidget(self.search_frame, 0)
+        layout.addWidget(self.speaker_filter_frame, 0)
 
         self.media_splitter = QSplitter(Qt.Orientation.Vertical)
         self.media_splitter.setHandleWidth(8)
@@ -322,6 +359,8 @@ class TranscriptionViewerWidget(QWidget):
         self.media_splitter.addWidget(self.media_player_stack)
         self.media_splitter.setCollapsible(0, False)
         self.media_splitter.setCollapsible(1, False)
+        self.media_splitter.setStretchFactor(0, 1)
+        self.media_splitter.setStretchFactor(1, 0)
         self.media_splitter.splitterMoved.connect(self.on_splitter_moved)
 
         self.create_loop_controls()
@@ -809,7 +848,8 @@ class TranscriptionViewerWidget(QWidget):
                 break
 
             text = segment.value("text").lower()
-            if search_text_lower in text:
+            speaker = (segment.value("speaker") or "").lower()
+            if search_text_lower in text or search_text_lower in speaker:
                 self.search_results.append(("table", i, segment))
 
         # Also search in translations if available
@@ -945,7 +985,11 @@ class TranscriptionViewerWidget(QWidget):
         self.search_next_button.setEnabled(False)
 
         # Clear text highlighting
-        if self.view_mode in (ViewMode.TEXT, ViewMode.TRANSLATION):
+        if self.view_mode in (
+            ViewMode.TEXT,
+            ViewMode.TRANSLATION,
+            ViewMode.SPEAKERS,
+        ):
             cursor = QTextCursor(self.text_display_box.document())
             cursor.clearSelection()
             self.text_display_box.setTextCursor(cursor)
@@ -1075,11 +1119,137 @@ class TranscriptionViewerWidget(QWidget):
                 return True
         return super().eventFilter(obj, event)
 
+    def _refresh_speaker_filter(self):
+        if not hasattr(self, "speaker_filter_combo"):
+            return
+
+        previous_filter = (
+            self.speaker_filter_combo.currentData()
+            if self.speaker_filter_combo.count()
+            else None
+        )
+        segments = self.transcription_service.get_transcription_segments(
+            transcription_id=self.transcription.id_as_uuid
+        )
+        speakers = []
+        has_unassigned = False
+        for segment in segments:
+            speaker = segment.speaker.strip()
+            if speaker:
+                if speaker not in speakers:
+                    speakers.append(speaker)
+            else:
+                has_unassigned = True
+
+        self.speaker_filter_combo.blockSignals(True)
+        self.speaker_filter_combo.clear()
+        self.speaker_filter_combo.addItem(_("All speakers"), None)
+        for speaker in speakers:
+            self.speaker_filter_combo.addItem(speaker, speaker)
+        if has_unassigned:
+            self.speaker_filter_combo.addItem(_("Unassigned"), "")
+
+        previous_index = self.speaker_filter_combo.findData(previous_filter)
+        self.speaker_filter_combo.setCurrentIndex(max(previous_index, 0))
+        self.speaker_filter_combo.blockSignals(False)
+
+    def _render_speakers_view(self, _index=None):
+        if not hasattr(self, "text_display_box"):
+            return
+
+        segments = self.transcription_service.get_transcription_segments(
+            transcription_id=self.transcription.id_as_uuid
+        )
+        selected_speaker = (
+            self.speaker_filter_combo.currentData()
+            if hasattr(self, "speaker_filter_combo")
+            else None
+        )
+
+        paragraph_split_time = int(
+            os.getenv("BUZZ_PARAGRAPH_SPLIT_TIME", "2000")
+        )
+        groups, speaker_order = group_speaker_segments(
+            segments,
+            paragraph_split_time=paragraph_split_time,
+        )
+
+        colors = {
+            speaker: QColor(SPEAKER_COLORS[index % len(SPEAKER_COLORS)])
+            for index, speaker in enumerate(speaker_order)
+        }
+        default_text_color = self.text_display_box.palette().color(
+            QPalette.ColorRole.Text
+        )
+
+        self.text_display_box.clear()
+        cursor = self.text_display_box.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
+        rendered_group_count = 0
+
+        for group in groups:
+            speaker = group.speaker
+            if selected_speaker is not None and speaker != selected_speaker:
+                continue
+
+            speaker_label = speaker or _("Unassigned")
+            label_format = QTextCharFormat()
+            label_format.setFontWeight(QFont.Weight.Bold)
+            label_format.setForeground(
+                colors.get(speaker, QColor("#757575"))
+            )
+            cursor.insertText(f"● {speaker_label}\n", label_format)
+
+            body_format = QTextCharFormat()
+            body_format.setForeground(default_text_color)
+            cursor.insertText(group.text + "\n\n", body_format)
+            rendered_group_count += 1
+
+        if rendered_group_count == 0:
+            empty_format = QTextCharFormat()
+            empty_format.setForeground(default_text_color)
+            cursor.insertText(_("No segments for this speaker."), empty_format)
+
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
+        self.text_display_box.setTextCursor(cursor)
+
+    def on_speakers_changed(self, speakers: list[str]):
+        self.has_speakers = bool(speakers)
+        if hasattr(self, "view_mode_tool_button"):
+            self.view_mode_tool_button.on_speakers_changed(speakers)
+        self._refresh_speaker_filter()
+
+        if self.view_mode == ViewMode.SPEAKERS:
+            if not self.has_speakers:
+                self.view_mode = ViewMode.TIMESTAMPS
+                self.reset_view()
+            else:
+                self._render_speakers_view()
+
+    def _set_plain_text_display(self, text: str):
+        """Replace rich speaker styling with the normal text-view format."""
+        self.text_display_box.setPlainText(text)
+
+        plain_format = QTextCharFormat()
+        plain_format.setFontWeight(QFont.Weight.Normal)
+        plain_format.setForeground(
+            self.text_display_box.palette().color(QPalette.ColorRole.Text)
+        )
+
+        cursor = QTextCursor(self.text_display_box.document())
+        cursor.select(QTextCursor.SelectionType.Document)
+        cursor.setCharFormat(plain_format)
+        cursor.clearSelection()
+        cursor.movePosition(QTextCursor.MoveOperation.Start)
+        self.text_display_box.setTextCursor(cursor)
+        self.text_display_box.setCurrentCharFormat(plain_format)
+
     def reset_view(self):
         if hasattr(self, 'media_splitter'):
             self.load_splitter_sizes()
 
         if self.view_mode == ViewMode.TIMESTAMPS:
+            self.speaker_filter_frame.hide()
             self.text_display_box.hide()
             self.table_widget.show()
             self.media_splitter.show()
@@ -1089,6 +1259,7 @@ class TranscriptionViewerWidget(QWidget):
             if self.playback_controls_visible:
                 self.loop_controls_frame.show()
         elif self.view_mode == ViewMode.TEXT:
+            self.speaker_filter_frame.hide()
             segments = self.transcription_service.get_transcription_segments(
                 transcription_id=self.transcription.id_as_uuid
             )
@@ -1102,10 +1273,13 @@ class TranscriptionViewerWidget(QWidget):
             for segment in segments:
                 if previous_end_time is not None and (segment.start_time - previous_end_time) >= paragraph_split_time:
                     combined_text += "\n\n"
-                combined_text += segment.text.strip() + " "
+                text = segment.text.strip()
+                if segment.speaker.strip():
+                    text = f"{segment.speaker.strip()}: {text}"
+                combined_text += text + " "
                 previous_end_time = segment.end_time
 
-            self.text_display_box.setPlainText(combined_text.strip())
+            self._set_plain_text_display(combined_text.strip())
             self.text_display_box.show()
             self.table_widget.hide()
             self.media_splitter.hide()
@@ -1115,12 +1289,31 @@ class TranscriptionViewerWidget(QWidget):
             self.loop_controls_frame.hide()
             # Hide current segment display in text mode
             self.current_segment_frame.hide()
+        elif self.view_mode == ViewMode.SPEAKERS:
+            self.speaker_filter_frame.show()
+            self._refresh_speaker_filter()
+            self._render_speakers_view()
+            self.text_display_box.show()
+            self.table_widget.hide()
+            self.media_splitter.hide()
+            if self.current_media_player:
+                self.current_media_player.hide()
+            self.loop_controls_frame.hide()
+            self.current_segment_frame.hide()
         else:  # ViewMode.TRANSLATION
+            self.speaker_filter_frame.hide()
             segments = self.transcription_service.get_transcription_segments(
                 transcription_id=self.transcription.id_as_uuid
             )
-            self.text_display_box.setPlainText(
-                " ".join(segment.translation.strip() for segment in segments)
+            self._set_plain_text_display(
+                " ".join(
+                    (
+                        f"{segment.speaker.strip()}: {segment.translation.strip()}"
+                        if segment.speaker.strip()
+                        else segment.translation.strip()
+                    )
+                    for segment in segments
+                )
             )
             self.text_display_box.show()
             self.table_widget.hide()
@@ -1137,6 +1330,8 @@ class TranscriptionViewerWidget(QWidget):
             self.perform_search()
 
     def on_view_mode_changed(self, view_mode: ViewMode) -> None:
+        if view_mode == ViewMode.SPEAKERS and not self.has_speakers:
+            return
         self.view_mode = view_mode
         self.reset_view()
 
@@ -1150,7 +1345,11 @@ class TranscriptionViewerWidget(QWidget):
 
         # Show the current segment frame and update the text
         self.current_segment_frame.show()
-        self.current_segment_text.setText(segment.value("text"))
+        segment_text = segment.value("text")
+        speaker = (segment.value("speaker") or "").strip()
+        if speaker:
+            segment_text = f"{speaker}: {segment_text}"
+        self.current_segment_text.setText(segment_text)
 
         # Force the text label to recalculate its size
         self.current_segment_text.adjustSize()

--- a/tests/db/speaker_schema_test.py
+++ b/tests/db/speaker_schema_test.py
@@ -1,0 +1,62 @@
+import sqlite3
+
+from buzz.db.helpers import run_sqlite_migrations
+
+
+def test_speaker_column_migration_preserves_existing_transcript_text(tmp_path):
+    database_path = tmp_path / "old-buzz.sqlite"
+    connection = sqlite3.connect(database_path)
+    connection.executescript(
+        """
+        CREATE TABLE transcription (
+            id TEXT PRIMARY KEY,
+            error_message TEXT,
+            export_formats TEXT,
+            file TEXT,
+            output_folder TEXT,
+            progress DOUBLE PRECISION DEFAULT 0.0,
+            language TEXT,
+            model_type TEXT,
+            source TEXT,
+            status TEXT,
+            task TEXT,
+            time_ended TIMESTAMP,
+            time_queued TIMESTAMP NOT NULL,
+            time_started TIMESTAMP,
+            url TEXT,
+            whisper_model_size TEXT,
+            hugging_face_model_id TEXT,
+            word_level_timings BOOLEAN DEFAULT FALSE,
+            extract_speech BOOLEAN DEFAULT FALSE,
+            name TEXT,
+            notes TEXT
+        );
+        CREATE TABLE transcription_segment (
+            id INTEGER PRIMARY KEY,
+            end_time INT DEFAULT 0,
+            start_time INT DEFAULT 0,
+            text TEXT NOT NULL,
+            translation TEXT DEFAULT '',
+            transcription_id TEXT,
+            FOREIGN KEY (transcription_id) REFERENCES transcription(id)
+                ON DELETE CASCADE
+        );
+        CREATE INDEX idx_transcription_id
+            ON transcription_segment(transcription_id);
+        INSERT INTO transcription (id, time_queued)
+            VALUES ('transcript-1', '2026-08-19');
+        INSERT INTO transcription_segment (
+            id, start_time, end_time, text, translation, transcription_id
+        ) VALUES (
+            1, 0, 1000, 'Nyomi: keep this exact text', '', 'transcript-1'
+        );
+        """
+    )
+
+    run_sqlite_migrations(connection)
+
+    row = connection.execute(
+        "SELECT text, speaker FROM transcription_segment WHERE id = 1"
+    ).fetchone()
+    connection.close()
+    assert row == ("Nyomi: keep this exact text", "")

--- a/tests/widgets/export_transcription_menu_test.py
+++ b/tests/widgets/export_transcription_menu_test.py
@@ -1,8 +1,11 @@
 import pathlib
 import uuid
+import zipfile
+from xml.etree import ElementTree
 
 import pytest
 from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
 from buzz.db.entity.transcription import Transcription
@@ -71,3 +74,99 @@ class TestExportTranscriptionMenu:
 
         with open(output_file_path, encoding="utf-8") as output_file:
             assert "Bien venue dans" in output_file.read()
+
+    def test_should_include_structured_speaker_in_export(
+        self,
+        tmp_path: pathlib.Path,
+        qtbot: QtBot,
+        transcription,
+        transcription_service,
+        mocker,
+    ):
+        segments = transcription_service.get_transcription_segments(
+            transcription.id_as_uuid
+        )
+        transcription_service.update_segment_speaker(segments[0].id, "Nyomi")
+        output_file_path = tmp_path / "speakers.txt"
+        mocker.patch(
+            "PyQt6.QtWidgets.QFileDialog.getSaveFileName",
+            return_value=(str(output_file_path), ""),
+        )
+        translation_signal = TranslationSignal()
+        widget = ExportTranscriptionMenu(
+            transcription,
+            transcription_service,
+            False,
+            translation_signal.translation,
+        )
+        qtbot.add_widget(widget)
+
+        widget.actions()[0].trigger()
+
+        assert output_file_path.read_text(encoding="utf-8").startswith(
+            "Nyomi: Bien"
+        )
+
+    def test_should_export_colored_speaker_docx_with_optional_timestamps(
+        self,
+        tmp_path: pathlib.Path,
+        qtbot: QtBot,
+        transcription,
+        transcription_service,
+        mocker,
+    ):
+        segments = transcription_service.get_transcription_segments(
+            transcription.id_as_uuid
+        )
+        transcription_service.update_segment_speaker(segments[0].id, "Nyomi")
+        transcription_service.update_segment_speaker(
+            segments[1].id,
+            "Mediator",
+        )
+        output_file_path = tmp_path / "hearing.docx"
+        mocker.patch(
+            "PyQt6.QtWidgets.QFileDialog.getSaveFileName",
+            return_value=(str(output_file_path), ""),
+        )
+        mocker.patch(
+            "PyQt6.QtWidgets.QMessageBox.question",
+            return_value=QMessageBox.StandardButton.Yes,
+        )
+        translation_signal = TranslationSignal()
+        widget = ExportTranscriptionMenu(
+            transcription,
+            transcription_service,
+            False,
+            translation_signal.translation,
+        )
+        qtbot.add_widget(widget)
+
+        assert widget.speaker_docx_action.isEnabled()
+        widget.speaker_docx_action.trigger()
+
+        with zipfile.ZipFile(output_file_path) as docx:
+            document = docx.read("word/document.xml").decode("utf-8")
+
+        ElementTree.fromstring(document)
+        assert "Nyomi" in document
+        assert "Mediator" in document
+        assert 'w:color w:val="1976D2"' in document
+        assert 'w:color w:val="C62828"' in document
+        assert "[00:00:00.040 – 00:00:00.299]" in document
+
+    def test_speaker_docx_export_is_disabled_without_assigned_speakers(
+        self,
+        qtbot: QtBot,
+        transcription,
+        transcription_service,
+    ):
+        translation_signal = TranslationSignal()
+        widget = ExportTranscriptionMenu(
+            transcription,
+            transcription_service,
+            False,
+            translation_signal.translation,
+        )
+        qtbot.add_widget(widget)
+
+        assert not widget.speaker_docx_action.isEnabled()

--- a/tests/widgets/speaker_identification_widget_test.py
+++ b/tests/widgets/speaker_identification_widget_test.py
@@ -257,6 +257,12 @@ class TestSpeakerIdentificationWidget:
         segments = mock_update.call_args[0][1]
         # No merge: 3 entries → 3 segments
         assert len(segments) == 3
+        assert [segment.speaker for segment in segments] == [
+            "Speaker 0",
+            "Speaker 0",
+            "Speaker 1",
+        ]
+        assert segments[0].text == "Hello."
 
         widget.close()
 
@@ -282,7 +288,8 @@ class TestSpeakerIdentificationWidget:
         segments = mock_update.call_args[0][1]
         # Merge: two consecutive Speaker 0 entries → merged into 1; Speaker 1 → 1 = 2 total
         assert len(segments) == 2
-        assert "Speaker 0" in segments[0].text
+        assert segments[0].speaker == "Speaker 0"
+        assert "Speaker 0" not in segments[0].text
         assert "Hello." in segments[0].text
         assert "World." in segments[0].text
 

--- a/tests/widgets/transcription_viewer/speaker_editor_test.py
+++ b/tests/widgets/transcription_viewer/speaker_editor_test.py
@@ -1,0 +1,218 @@
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6.QtGui import QFont, QPalette, QTextCursor
+from PyQt6.QtWidgets import QTableView
+from pytestqt.qtbot import QtBot
+
+from buzz.db.entity.transcription import Transcription
+from buzz.db.entity.transcription_segment import TranscriptionSegment
+from buzz.model_loader import ModelType, WhisperModelSize
+from buzz.transcriber.transcriber import Task
+from buzz.widgets.transcription_viewer.transcription_segments_editor_widget import (
+    Column,
+    SPEAKER_COLORS,
+    TranscriptionSegmentsEditorWidget,
+)
+from buzz.widgets.transcription_viewer.transcription_view_mode_tool_button import (
+    ViewMode,
+)
+from buzz.widgets.transcription_viewer.transcription_viewer_widget import (
+    TranscriptionViewerWidget,
+)
+from tests.audio import test_audio_path
+
+
+@pytest.fixture()
+def speaker_transcription(transcription_dao, transcription_segment_dao):
+    transcription_id = uuid.uuid4()
+    transcription_dao.insert(
+        Transcription(
+            id=str(transcription_id),
+            status="completed",
+            file=test_audio_path,
+            task=Task.TRANSCRIBE.value,
+            model_type=ModelType.WHISPER.value,
+            whisper_model_size=WhisperModelSize.TINY.value,
+        )
+    )
+    transcription_segment_dao.insert(
+        TranscriptionSegment(
+            0, 1000, "First statement.", "", str(transcription_id), "Nyomi"
+        )
+    )
+    transcription_segment_dao.insert(
+        TranscriptionSegment(
+            1000, 2000, "Second statement.", "", str(transcription_id), "Nyomi"
+        )
+    )
+    transcription_segment_dao.insert(
+        TranscriptionSegment(
+            2000, 3000, "A question.", "", str(transcription_id), "Mediator"
+        )
+    )
+    return transcription_dao.find_by_id(str(transcription_id))
+
+
+def test_speaker_column_supports_bulk_assignment(
+    qtbot: QtBot, speaker_transcription, transcription_service
+):
+    widget = TranscriptionSegmentsEditorWidget(
+        transcription_id=speaker_transcription.id_as_uuid,
+        translator=MagicMock(),
+        parent=None,
+    )
+    qtbot.add_widget(widget)
+
+    assert widget.selectionMode() == QTableView.SelectionMode.ExtendedSelection
+    assert widget.speaker_names() == ["Nyomi", "Mediator"]
+
+    widget.assign_speaker_to_rows([2], "Nyomi")
+    assert widget.model().record(2).value("speaker") == "Nyomi"
+    assert widget.speaker_names() == ["Nyomi"]
+    assert all(
+        widget.model().record(row).value("speaker") == "Nyomi"
+        for row in range(widget.model().rowCount())
+    )
+
+
+def test_speaker_delegate_accepts_a_new_name(
+    qtbot: QtBot, speaker_transcription
+):
+    widget = TranscriptionSegmentsEditorWidget(
+        transcription_id=speaker_transcription.id_as_uuid,
+        translator=MagicMock(),
+        parent=None,
+    )
+    qtbot.add_widget(widget)
+    index = widget.model().index(0, Column.SPEAKER.value)
+    editor = widget.speaker_delegate.createEditor(widget, None, index)
+    editor.setEditText("New participant")
+
+    widget.speaker_delegate.setModelData(editor, widget.model(), index)
+
+    assert widget.model().record(0).value("speaker") == "New participant"
+
+
+def test_speakers_view_is_colored_named_grouped_and_filterable(
+    qtbot: QtBot,
+    speaker_transcription,
+    transcription_service,
+    shortcuts,
+):
+    widget = TranscriptionViewerWidget(
+        speaker_transcription, transcription_service, shortcuts
+    )
+    qtbot.add_widget(widget)
+
+    assert widget.view_mode_tool_button.speakers_action.isEnabled()
+    widget.on_view_mode_changed(ViewMode.SPEAKERS)
+    rendered = widget.text_display_box.toPlainText()
+    assert "● Nyomi" in rendered
+    assert "First statement. Second statement." in rendered
+    assert "● Mediator" in rendered
+
+    nyomi_index = widget.speaker_filter_combo.findData("Nyomi")
+    widget.speaker_filter_combo.setCurrentIndex(nyomi_index)
+    filtered = widget.text_display_box.toPlainText()
+    assert "First statement." in filtered
+    assert "A question." not in filtered
+    assert "● Nyomi" in filtered
+
+    label_cursor = QTextCursor(widget.text_display_box.document())
+    label_cursor.setPosition(0)
+    label_cursor.movePosition(
+        QTextCursor.MoveOperation.NextCharacter,
+        QTextCursor.MoveMode.KeepAnchor,
+    )
+    assert label_cursor.selectedText() == "●"
+    assert label_cursor.charFormat().foreground().color().name() == SPEAKER_COLORS[0].lower()
+    widget.close()
+
+
+def test_text_view_resets_speaker_label_formatting(
+    qtbot: QtBot,
+    speaker_transcription,
+    transcription_service,
+    shortcuts,
+):
+    widget = TranscriptionViewerWidget(
+        speaker_transcription, transcription_service, shortcuts
+    )
+    qtbot.add_widget(widget)
+
+    widget.on_view_mode_changed(ViewMode.SPEAKERS)
+    widget.on_view_mode_changed(ViewMode.TEXT)
+
+    text_cursor = QTextCursor(widget.text_display_box.document())
+    text_cursor.setPosition(0)
+    text_cursor.movePosition(
+        QTextCursor.MoveOperation.NextCharacter,
+        QTextCursor.MoveMode.KeepAnchor,
+    )
+    text_format = text_cursor.charFormat()
+    assert text_format.fontWeight() == QFont.Weight.Normal
+    assert text_format.foreground().color() == widget.text_display_box.palette().color(
+        QPalette.ColorRole.Text
+    )
+    widget.close()
+
+
+def test_audio_viewer_keeps_transcript_table_expanded(
+    qtbot: QtBot,
+    speaker_transcription,
+    transcription_service,
+    shortcuts,
+):
+    widget = TranscriptionViewerWidget(
+        speaker_transcription, transcription_service, shortcuts
+    )
+    qtbot.add_widget(widget)
+    widget.resize(1200, 900)
+    widget.show()
+    qtbot.waitUntil(lambda: sum(widget.media_splitter.sizes()) > 0)
+
+    table_height, audio_height = widget.media_splitter.sizes()
+    assert audio_height <= widget.AUDIO_PLAYER_MAX_HEIGHT
+    assert table_height > audio_height * 4
+    widget.close()
+
+
+def test_colon_prefix_is_not_automatically_converted_to_a_speaker(
+    qtbot: QtBot,
+    transcription_dao,
+    transcription_segment_dao,
+    transcription_service,
+    shortcuts,
+):
+    transcription_id = uuid.uuid4()
+    transcription_dao.insert(
+        Transcription(
+            id=str(transcription_id),
+            status="completed",
+            file=test_audio_path,
+            task=Task.TRANSCRIBE.value,
+            model_type=ModelType.WHISPER.value,
+            whisper_model_size=WhisperModelSize.TINY.value,
+        )
+    )
+    transcription_segment_dao.insert(
+        TranscriptionSegment(
+            0,
+            1000,
+            "Nyomi: this remains ordinary transcript text.",
+            "",
+            str(transcription_id),
+        )
+    )
+    transcription = transcription_dao.find_by_id(str(transcription_id))
+    widget = TranscriptionViewerWidget(
+        transcription, transcription_service, shortcuts
+    )
+    qtbot.add_widget(widget)
+
+    assert widget.table_widget.speaker_names() == []
+    assert not widget.view_mode_tool_button.speakers_action.isEnabled()
+    assert widget.table_widget.model().record(0).value("speaker") == ""
+    widget.close()

--- a/tests/widgets/transcription_viewer/transcription_segments_editor_widget_test.py
+++ b/tests/widgets/transcription_viewer/transcription_segments_editor_widget_test.py
@@ -334,7 +334,7 @@ class TestTranscriptionSegmentsEditorWidget:
         qtbot.add_widget(widget)
 
         assert hasattr(widget, 'column_definitions')
-        assert len(widget.column_definitions) == 4
+        assert len(widget.column_definitions) == 5
 
         # Check that columns have proper delegates
         for col_def in widget.column_definitions:
@@ -541,7 +541,7 @@ class TestTranscriptionSegmentsEditorWidget:
         assert widget.selectionBehavior() == QAbstractItemView.SelectionBehavior.SelectRows
 
     def test_selection_mode(self, qtbot: QtBot, transcription, translator):
-        """Test that selection mode is set to SingleSelection"""
+        """Test that selection mode supports bulk speaker assignment"""
         widget = TranscriptionSegmentsEditorWidget(
             transcription_id=uuid.UUID(hex=transcription.id),
             translator=translator,
@@ -550,4 +550,4 @@ class TestTranscriptionSegmentsEditorWidget:
         qtbot.add_widget(widget)
 
         from PyQt6.QtWidgets import QTableView
-        assert widget.selectionMode() == QTableView.SelectionMode.SingleSelection
+        assert widget.selectionMode() == QTableView.SelectionMode.ExtendedSelection


### PR DESCRIPTION
## Summary

- persist diarization results in a dedicated `speaker` field instead of embedding labels into transcript text
- add an editable **Speaker** column to the timestamp editor, with inline choices, custom names, and multi-row assignment
- add a **Speakers** view with stable colors, explicit names, consecutive-turn grouping, and per-speaker filtering
- add **DOCX – Speakers** export with matching colored/bold speaker labels, normal black transcript text, and optional timestamps
- retain speaker context in TXT/SRT/VTT exports without polluting the stored transcript text
- safely migrate existing databases without heuristically parsing legacy `Name:` text prefixes

## Behavior

`Identify Speakers` now saves clean transcript text and structured speaker metadata. The Speakers view and DOCX export share the same grouping and color model, so the on-screen result and Word document remain consistent. Both features are available only when at least one speaker is assigned.

In the timestamp table, users can edit a speaker per row, create a new speaker name, or assign one speaker to multiple selected rows. The generated Word document is a normal, editable `.docx` file.

## Motivation

This completes the editing and export side of the known-speaker workflow discussed in #1043 and complements #1586. Importantly, the structured speaker model is independent of the diarization backend: MSDD, Sortformer, or a future model can all populate the same field and use the same editor, view, filters, and exports.

That makes this useful beyond the current MSDD speaker-count implementation, especially for interviews, meetings, hearings, and court-style transcripts that need review and document export after diarization.

## Additional UI fixes

- keep the audio control area compact so the transcript table uses the available height
- reset rich speaker-label formatting when returning to the plain Text view

## Testing

- **53 passed, 30 skipped** in the focused schema, editor, identification, export, and DOCX plugin suites
- database migration test confirms existing transcript text is preserved
- generated DOCX XML is validated and checked for speaker names, colors, and optional timestamps
- user validation on a 30-minute Hungarian room recording with three participants
- manual Windows testing confirmed speaker editing, filtering, and the colored Word export
