### PR TITLE
Fix URL downloads with trailing-dot titles on Windows

### DIFF
--- a/buzz/db/entity/transcription.py
+++ b/buzz/db/entity/transcription.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 
 from buzz.db.entity.entity import Entity
 from buzz.model_loader import ModelType
+from buzz.paths import safe_filename_component
 from buzz.settings.settings import Settings
 from buzz.transcriber.transcriber import OutputFormat, Task, FileTranscriptionTask
 
@@ -46,7 +47,9 @@ class Transcription(Entity):
         output_format: OutputFormat,
         output_directory: str | None = None,
     ):
-        input_file_name = os.path.splitext(os.path.basename(self.file))[0]
+        input_file_name = safe_filename_component(
+            self.name or os.path.splitext(os.path.basename(self.file))[0]
+        )
 
         date_time_now = datetime.datetime.now().strftime("%d-%b-%Y %H-%M-%S")
 

--- a/buzz/paths.py
+++ b/buzz/paths.py
@@ -1,5 +1,32 @@
 import os
+import re
+
+
+WINDOWS_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+WINDOWS_RESERVED_FILENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in range(1, 10)),
+}
 
 
 def file_path_as_title(file_path: str):
     return os.path.basename(file_path)
+
+
+def safe_filename_component(name: str, fallback: str = "transcript") -> str:
+    """Make metadata safe to use as one portable filename component."""
+    sanitized = WINDOWS_INVALID_FILENAME_CHARS.sub("_", name)
+    sanitized = re.sub(r"[ .]$", "#", sanitized)
+
+    if not sanitized:
+        return fallback
+
+    windows_stem = sanitized.split(".", 1)[0].rstrip(" .").upper()
+    if windows_stem in WINDOWS_RESERVED_FILENAMES:
+        sanitized = f"_{sanitized}"
+
+    return sanitized

--- a/buzz/transcriber/file_transcriber.py
+++ b/buzz/transcriber/file_transcriber.py
@@ -86,6 +86,7 @@ class FileTranscriber(QObject):
                 output_directory=self.transcription_task.output_directory,
                 model=self.transcription_task.transcription_options.model,
                 task=self.transcription_task.transcription_options.task,
+                display_name=self.transcription_task.display_name,
             )
 
             write_output(

--- a/buzz/transcriber/file_transcriber.py
+++ b/buzz/transcriber/file_transcriber.py
@@ -5,7 +5,7 @@ import subprocess
 import shutil
 import tempfile
 from abc import abstractmethod
-from typing import Optional, List
+from typing import Any, Optional, List
 from pathlib import Path
 
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
@@ -22,6 +22,29 @@ from buzz.transcriber.transcriber import (
 
 app_env = os.environ.copy()
 app_env['PATH'] = os.pathsep.join([os.path.join(APP_BASE_DIR, "_internal")] + [app_env['PATH']])
+
+
+def _downloaded_file_path(info: Any) -> Path:
+    """Return the actual file path reported by yt-dlp after downloading."""
+    candidates = []
+
+    if info is not None:
+        filepath = info.get("filepath")
+        if filepath:
+            candidates.append(filepath)
+
+        for download in info.get("requested_downloads") or []:
+            filepath = download.get("filepath")
+            if filepath:
+                candidates.append(filepath)
+
+    for candidate in candidates:
+        path = Path(candidate).resolve()
+        if path.is_file():
+            return path
+
+    reported_path = candidates[0] if candidates else "<no filepath reported>"
+    raise FileNotFoundError(f"yt-dlp output does not exist: {reported_path}")
 
 
 class FileTranscriber(QObject):
@@ -75,59 +98,46 @@ class FileTranscriber(QObject):
     def _download_from_url(self) -> bool:
         cookiefile = os.getenv("BUZZ_DOWNLOAD_COOKIEFILE")
 
-        extract_options = {
-            "logger": logging.getLogger(),
-        }
-        if cookiefile:
-            extract_options["cookiefile"] = cookiefile
-
-        try:
-            with YoutubeDL(extract_options) as ydl_info:
-                info = ydl_info.extract_info(self.transcription_task.url, download=False)
-                video_title = info.get("title", "audio")
-        except Exception as exc:
-            logging.debug(f"Error extracting video info: {exc}")
-            video_title = "audio"
-
-        video_title = YoutubeDL.sanitize_info({"title": video_title})["title"]
-        for char in ['/', '\\', ':', '*', '?', '"', '<', '>', '|']:
-            video_title = video_title.replace(char, '_')
-
-        temp_dir = tempfile.mkdtemp()
-        temp_output_path = os.path.join(temp_dir, video_title)
-        wav_file = temp_output_path + ".wav"
-        wav_file = str(Path(wav_file).resolve())
+        temp_dir = Path(tempfile.mkdtemp()).resolve()
+        # Never derive a working path from the media title. In particular,
+        # yt-dlp normalizes trailing dots and spaces differently on Windows.
+        download_template = str(temp_dir / "source.%(ext)s")
+        wav_file = temp_dir / "audio.wav"
 
         options = {
             "format": "bestaudio/best",
             "progress_hooks": [self.on_download_progress],
-            "outtmpl": temp_output_path,
+            "outtmpl": download_template,
             "logger": logging.getLogger(),
         }
 
         if cookiefile:
             options["cookiefile"] = cookiefile
 
-        ydl = YoutubeDL(options)
-
         try:
             logging.debug(f"Downloading audio file from URL: {self.transcription_task.url}")
-            ydl.download([self.transcription_task.url])
+            with YoutubeDL(options) as ydl:
+                info = ydl.extract_info(self.transcription_task.url, download=True)
+            downloaded_file = _downloaded_file_path(info)
+            title = info.get("title")
+            if title:
+                self.transcription_task.display_name = title
         except Exception as exc:
-            logging.debug(f"Error downloading audio: {exc.msg}")
-            self.error.emit(exc.msg)
+            message = getattr(exc, "msg", str(exc))
+            logging.debug(f"Error downloading audio: {message}")
+            self.error.emit(message)
             return False
 
         cmd = [
             "ffmpeg",
             "-nostdin",
             "-threads", "0",
-            "-i", temp_output_path,
+            "-i", str(downloaded_file),
             "-ac", "1",
             "-ar", str(whisper_audio.SAMPLE_RATE),
             "-acodec", "pcm_s16le",
             "-loglevel", "panic",
-            wav_file
+            str(wav_file)
         ]
 
         if sys.platform == "win32":
@@ -144,11 +154,22 @@ class FileTranscriber(QObject):
         else:
             result = subprocess.run(cmd, capture_output=True)
 
-        if len(result.stderr):
-            logging.warning(f"Error processing downloaded audio. Error: {result.stderr.decode()}")
-            raise Exception(f"Error processing downloaded audio: {result.stderr.decode()}")
+        if result.returncode != 0:
+            error = result.stderr.decode("utf-8", errors="replace")
+            if not error:
+                error = f"ffmpeg exited with code {result.returncode}"
+            message = f"Error processing downloaded audio: {error}"
+            logging.warning(message)
+            self.error.emit(message)
+            return False
 
-        self.transcription_task.file_path = wav_file
+        if not wav_file.is_file():
+            message = f"FFmpeg output does not exist: {wav_file}"
+            logging.warning(message)
+            self.error.emit(message)
+            return False
+
+        self.transcription_task.file_path = str(wav_file)
         logging.debug(f"Downloaded audio to file: {self.transcription_task.file_path}")
         return True
 

--- a/buzz/transcriber/transcriber.py
+++ b/buzz/transcriber/transcriber.py
@@ -11,6 +11,7 @@ from dataclasses_json import dataclass_json, config, Exclude
 
 from buzz.locale import _
 from buzz.model_loader import TranscriptionModel
+from buzz.paths import safe_filename_component
 from buzz.settings.settings import Settings
 
 DEFAULT_WHISPER_TEMPERATURE = (0.0, 0.2, 0.4, 0.6, 0.8, 1.0)
@@ -259,11 +260,13 @@ def get_output_file_path(
     output_format: OutputFormat,
     output_directory: str | None = None,
     export_file_name_template: str | None = None,
+    display_name: str | None = None,
 ):
-    input_file_name = os.path.splitext(os.path.basename(file_path))[0]
+    input_file_name = display_name or os.path.splitext(os.path.basename(file_path))[0]
     # Remove "_speech" suffix from extracted speech files
     if input_file_name.endswith("_speech"):
         input_file_name = input_file_name[:-7]
+    input_file_name = safe_filename_component(input_file_name)
     date_time_now = datetime.datetime.now().strftime("%d-%b-%Y %H-%M-%S")
 
     export_file_name_template = (

--- a/buzz/transcriber/transcriber.py
+++ b/buzz/transcriber/transcriber.py
@@ -208,6 +208,7 @@ class FileTranscriptionTask:
     original_file_path: Optional[str] = None  # Original path before speech extraction
     delete_source_file: bool = False
     url: Optional[str] = None
+    display_name: Optional[str] = None
     fraction_downloaded: float = 0.0
 
     def __post_init__(self):

--- a/buzz/widgets/main_window.py
+++ b/buzz/widgets/main_window.py
@@ -492,9 +492,9 @@ class MainWindow(QMainWindow):
         # Update file path in database only for URL imports where file is downloaded
         if task.source == FileTranscriptionTask.Source.URL_IMPORT and task.file_path:
             logging.debug(f"Updating transcription file path: {task.file_path}")
-            # Use the file basename (video title) as the display name
+            # URL titles are UI metadata and must not be used as working paths.
             basename = os.path.basename(task.file_path)
-            name = os.path.splitext(basename)[0]  # Remove .wav extension
+            name = task.display_name or os.path.splitext(basename)[0]
             self.transcription_service.update_transcription_file_and_name(task.uid, task.file_path, name)
 
         # When plugins are enabled, run the after_transcription / save / on_complete

--- a/buzz/widgets/transcription_viewer/export_transcription_menu.py
+++ b/buzz/widgets/transcription_viewer/export_transcription_menu.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import QWidget, QMenu, QFileDialog, QMessageBox
 from buzz.db.entity.transcription import Transcription
 from buzz.db.service.transcription_service import TranscriptionService
 from buzz.locale import _
+from buzz.paths import safe_filename_component
 from buzz.transcriber.file_transcriber import write_output
 from buzz.transcriber.docx_writer import write_speaker_docx
 from buzz.transcriber.transcriber import (
@@ -139,11 +140,12 @@ class ExportTranscriptionMenu(QMenu):
 
         source_path = self.transcription.file or "transcript"
         source_directory = os.path.dirname(source_path)
-        source_stem = (
+        source_title = (
             self.transcription.name
             or os.path.splitext(os.path.basename(source_path))[0]
             or "transcript"
         )
+        source_stem = safe_filename_component(source_title)
         default_path = os.path.join(
             source_directory,
             f"{source_stem}_speakers.docx",
@@ -162,7 +164,7 @@ class ExportTranscriptionMenu(QMenu):
         try:
             write_speaker_docx(
                 output_file_path,
-                source_stem,
+                source_title,
                 segments,
                 include_timestamps=(
                     timestamp_choice == QMessageBox.StandardButton.Yes

--- a/tests/db/entity/transcription_test.py
+++ b/tests/db/entity/transcription_test.py
@@ -1,10 +1,30 @@
-import pytest
 from uuid import uuid4
 
 from buzz.db.entity.transcription import Transcription
+from buzz.transcriber.transcriber import FileTranscriptionTask, OutputFormat
 
 
 class TestTranscription:
+    def test_url_export_uses_safe_name_instead_of_internal_audio_name(
+        self, monkeypatch, tmp_path
+    ):
+        title = "中文 | test?."
+        transcription = Transcription(
+            file=str(tmp_path / "audio.wav"),
+            name=title,
+            source=FileTranscriptionTask.Source.URL_IMPORT.value,
+        )
+        monkeypatch.setattr(
+            "buzz.db.entity.transcription.Settings.get_default_export_file_template",
+            lambda _settings: "{{ input_file_name }}",
+        )
+
+        output_path = transcription.get_output_file_path(OutputFormat.SRT)
+
+        assert transcription.name == title
+        assert output_path != str(tmp_path / "audio.srt")
+        assert output_path == str(tmp_path / "中文 _ test_#.srt")
+
     def test_transcription_creation_with_name_and_notes(self):
         """Test creating a transcription with name and notes fields"""
         transcription = Transcription(

--- a/tests/paths_test.py
+++ b/tests/paths_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from buzz.paths import safe_filename_component
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("中文 | QVD-123.", "中文 _ QVD-123#"),
+        ("foo:bar?.wav", "foo_bar_.wav"),
+        ("trailing-dot.", "trailing-dot#"),
+        ("trailing-space ", "trailing-space#"),
+        ("emoji-🚀", "emoji-🚀"),
+        ("CON", "_CON"),
+    ],
+)
+def test_safe_filename_component(name, expected):
+    assert safe_filename_component(name) == expected

--- a/tests/transcriber/file_transcriber_test.py
+++ b/tests/transcriber/file_transcriber_test.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from buzz.transcriber.file_transcriber import FileTranscriber, _downloaded_file_path
+from buzz.transcriber.transcriber import (
+    FileTranscriptionOptions,
+    FileTranscriptionTask,
+    TranscriptionOptions,
+)
+
+
+class ConcreteFileTranscriber(FileTranscriber):
+    def transcribe(self):
+        return []
+
+    def stop(self):
+        pass
+
+
+def make_transcriber() -> ConcreteFileTranscriber:
+    return ConcreteFileTranscriber(
+        FileTranscriptionTask(
+            transcription_options=TranscriptionOptions(),
+            file_transcription_options=FileTranscriptionOptions(),
+            model_path="",
+            url="https://example.com/video",
+            source=FileTranscriptionTask.Source.URL_IMPORT,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "中文标题 | QVD-123.",
+        "foo:bar?.wav",
+        "trailing-dot.",
+        "trailing-space ",
+        "emoji-🚀",
+    ],
+)
+def test_url_download_uses_reported_path_instead_of_title(
+    monkeypatch, tmp_path, title
+):
+    transcriber = make_transcriber()
+    calls = {}
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            calls["options"] = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def extract_info(self, url, download):
+            calls["extract_info"] = (url, download)
+            downloaded_file = tmp_path / "actual-yt-dlp-output.m4a"
+            downloaded_file.write_bytes(b"downloaded audio")
+            return {
+                "title": title,
+                "requested_downloads": [{"filepath": str(downloaded_file)}],
+            }
+
+    def fake_run(command, **_kwargs):
+        calls["ffmpeg"] = command
+        Path(command[-1]).write_bytes(b"wav audio")
+        return Mock(returncode=0, stderr=b"")
+
+    monkeypatch.setattr("buzz.transcriber.file_transcriber.YoutubeDL", FakeYoutubeDL)
+    monkeypatch.setattr("buzz.transcriber.file_transcriber.subprocess.run", fake_run)
+
+    assert transcriber._download_from_url()
+
+    assert calls["extract_info"] == (transcriber.transcription_task.url, True)
+    assert Path(calls["options"]["outtmpl"]).name == "source.%(ext)s"
+    assert calls["ffmpeg"][calls["ffmpeg"].index("-i") + 1] == str(
+        tmp_path / "actual-yt-dlp-output.m4a"
+    )
+    assert Path(transcriber.transcription_task.file_path).is_file()
+    assert Path(transcriber.transcription_task.file_path).name == "audio.wav"
+    assert transcriber.transcription_task.display_name == title
+    assert title not in " ".join(calls["ffmpeg"])
+
+
+def test_downloaded_file_path_rejects_missing_reported_file(tmp_path):
+    missing = tmp_path / "missing.webm"
+
+    with pytest.raises(
+        FileNotFoundError, match=r"yt-dlp output does not exist: .*missing\.webm"
+    ):
+        _downloaded_file_path({"filepath": str(missing)})
+
+
+def test_url_download_rejects_ffmpeg_failure_with_empty_stderr(
+    monkeypatch, tmp_path
+):
+    transcriber = make_transcriber()
+    error = Mock()
+    transcriber.error.connect(error)
+    downloaded_file = tmp_path / "CVSS9#"
+    downloaded_file.write_bytes(b"downloaded audio")
+
+    class FakeYoutubeDL:
+        def __init__(self, _options):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def extract_info(self, _url, download):
+            assert download
+            return {"filepath": str(downloaded_file)}
+
+    monkeypatch.setattr("buzz.transcriber.file_transcriber.YoutubeDL", FakeYoutubeDL)
+    monkeypatch.setattr(
+        "buzz.transcriber.file_transcriber.subprocess.run",
+        Mock(return_value=Mock(returncode=1, stderr=b"")),
+    )
+
+    assert not transcriber._download_from_url()
+
+    assert transcriber.transcription_task.file_path is None
+    error.assert_called_once_with(
+        "Error processing downloaded audio: ffmpeg exited with code 1"
+    )
+
+
+def test_url_download_rejects_missing_ffmpeg_output(monkeypatch, tmp_path):
+    transcriber = make_transcriber()
+    error = Mock()
+    transcriber.error.connect(error)
+    downloaded_file = tmp_path / "CVSS9#"
+    downloaded_file.write_bytes(b"downloaded audio")
+
+    class FakeYoutubeDL:
+        def __init__(self, _options):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def extract_info(self, _url, download):
+            assert download
+            return {"filepath": str(downloaded_file)}
+
+    monkeypatch.setattr("buzz.transcriber.file_transcriber.YoutubeDL", FakeYoutubeDL)
+    monkeypatch.setattr(
+        "buzz.transcriber.file_transcriber.subprocess.run",
+        Mock(return_value=Mock(returncode=0, stderr=b"")),
+    )
+
+    assert not transcriber._download_from_url()
+
+    assert transcriber.transcription_task.file_path is None
+    error.assert_called_once()
+    assert error.call_args.args[0].startswith("FFmpeg output does not exist:")

--- a/tests/transcriber/transcriber_test.py
+++ b/tests/transcriber/transcriber_test.py
@@ -2,10 +2,13 @@ import pathlib
 
 import pytest
 
+from buzz.model_loader import TranscriptionModel
 from buzz.transcriber.file_transcriber import write_output, to_timestamp
 from buzz.transcriber.transcriber import (
+    get_output_file_path,
     OutputFormat,
     Segment,
+    Task,
 )
 
 
@@ -13,6 +16,23 @@ class TestToTimestamp:
     def test_to_timestamp(self):
         assert to_timestamp(0) == "00:00:00.000"
         assert to_timestamp(123456789) == "34:17:36.789"
+
+
+def test_url_output_path_uses_safe_display_name(tmp_path):
+    title = "中文 | test?."
+
+    output_path = get_output_file_path(
+        file_path=str(tmp_path / "audio.wav"),
+        task=Task.TRANSCRIBE,
+        language=None,
+        model=TranscriptionModel(),
+        output_format=OutputFormat.SRT,
+        export_file_name_template="{{ input_file_name }}",
+        display_name=title,
+    )
+
+    assert title == "中文 | test?."
+    assert pathlib.Path(output_path).name == "中文 _ test_#.srt"
 
 
 @pytest.mark.parametrize(

--- a/tests/widgets/export_transcription_menu_test.py
+++ b/tests/widgets/export_transcription_menu_test.py
@@ -1,11 +1,12 @@
 import pathlib
 import uuid
 import zipfile
+from unittest.mock import Mock
 from xml.etree import ElementTree
 
 import pytest
 from PyQt6.QtCore import QObject, pyqtSignal
-from PyQt6.QtWidgets import QMessageBox
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
 from pytestqt.qtbot import QtBot
 
 from buzz.db.entity.transcription import Transcription
@@ -170,3 +171,40 @@ class TestExportTranscriptionMenu:
         qtbot.add_widget(widget)
 
         assert not widget.speaker_docx_action.isEnabled()
+
+    def test_speaker_docx_default_path_sanitizes_name(
+        self,
+        tmp_path: pathlib.Path,
+        qtbot: QtBot,
+        monkeypatch,
+    ):
+        title = "中文 | test?."
+        transcription = Transcription(
+            file=str(tmp_path / "audio.wav"),
+            name=title,
+        )
+        transcription_service = Mock()
+        transcription_service.get_transcription_segments.return_value = [
+            Mock(speaker="Speaker")
+        ]
+        get_save_file_name = Mock(return_value=("", ""))
+        monkeypatch.setattr(QFileDialog, "getSaveFileName", get_save_file_name)
+        monkeypatch.setattr(
+            QMessageBox,
+            "question",
+            Mock(return_value=QMessageBox.StandardButton.No),
+        )
+        translation_signal = TranslationSignal()
+        widget = ExportTranscriptionMenu(
+            transcription,
+            transcription_service,
+            False,
+            translation_signal.translation,
+        )
+        qtbot.add_widget(widget)
+
+        widget.export_speakers_docx()
+
+        default_path = get_save_file_name.call_args.args[2]
+        assert transcription.name == title
+        assert pathlib.Path(default_path).name == "中文 _ test_#_speakers.docx"


### PR DESCRIPTION
## Summary

- stop deriving URL-download working paths from media titles
- use yt-dlp's reported `filepath` as the ffmpeg input
- validate both ffmpeg's exit code and the existence of its WAV output
- keep the original remote title as display metadata
- sanitize the title only when materializing user-visible export filenames
- preserve title-based names for automatic TXT/SRT/VTT and speaker DOCX exports instead of falling back to `audio.*`

## Root cause

Buzz replaced several Windows-invalid characters in the title, but did not normalize trailing dots or spaces. For a title ending in `CVSS9.`, Buzz expected that literal path while yt-dlp's Windows path sanitizer created `CVSS9#`. ffmpeg therefore received a nonexistent input path.

The failure was then masked because Buzz treated empty stderr as success instead of checking `returncode`. With `-loglevel panic`, ffmpeg could exit nonzero without stderr, so Buzz assigned a nonexistent WAV path and Whisper/PyAV failed later.

## Path boundaries

This change separates three concepts:

- remote title: preserved exactly as display/document metadata
- internal working path: fixed safe names such as `source.%(ext)s` and `audio.wav`
- exported filename: derived from the title through one portable filename-component sanitizer

The sanitizer covers Windows-invalid characters, trailing dots/spaces, control characters, and reserved device names. Speaker DOCX files use the sanitized stem for the filesystem path while retaining the original title inside the document.

## Regression coverage

Covers Chinese titles, invalid characters, trailing dots, trailing spaces, emoji, reserved Windows names, yt-dlp-reported paths, nonzero ffmpeg exits with empty stderr, missing WAV output, title-based regular exports, and speaker DOCX default paths.

Tested with `uv`: 35 targeted tests passed, and Ruff passed.