### PR TITLE
Support multiple custom Whisper.cpp models

### DIFF
--- a/buzz/cli.py
+++ b/buzz/cli.py
@@ -73,6 +73,12 @@ def _add_command_options(parser: QCommandLineParser):
         'Hugging Face model ID. Use only when --model-type is huggingface. Example: "openai/whisper-tiny"',
         "id",
     )
+    custom_model_id_option = QCommandLineOption(
+        ["custom-model-id"],
+        "Id of a registered Whisper.cpp custom model. Use only when --model-type is "
+        "whispercpp and --model-size is custom.",
+        "id",
+    )
     language_option = QCommandLineOption(
         ["l", "language"],
         f'Language code. Allowed: {", ".join(sorted([k + " (" + LANGUAGES[k].title() + ")" for k in LANGUAGES]))}. Leave empty to detect language.',
@@ -107,6 +113,7 @@ def _add_command_options(parser: QCommandLineParser):
             model_type_option,
             model_size_option,
             hugging_face_model_id_option,
+            custom_model_id_option,
             language_option,
             initial_prompt_option,
             word_timestamp_option,
@@ -125,6 +132,7 @@ def _add_command_options(parser: QCommandLineParser):
         "model_type": model_type_option,
         "model_size": model_size_option,
         "hugging_face_model_id": hugging_face_model_id_option,
+        "custom_model_id": custom_model_id_option,
         "language": language_option,
         "initial_prompt": initial_prompt_option,
         "word_timestamps": word_timestamp_option,
@@ -142,6 +150,7 @@ def _resolve_model(
     model_type: CommandLineModelType,
     model_size: WhisperModelSize,
     hugging_face_model_id: str,
+    custom_model_id: str = "",
 ):
     if hugging_face_model_id == "" and model_type == CommandLineModelType.HUGGING_FACE:
         raise CommandLineError("--hfid is required when --model-type is huggingface")
@@ -149,6 +158,7 @@ def _resolve_model(
         model_type=ModelType[model_type.name],
         whisper_model_size=model_size,
         hugging_face_model_id=hugging_face_model_id,
+        custom_model_id=custom_model_id or None,
     )
     model_path = model.get_local_model_path()
     if model_path is None:
@@ -217,7 +227,10 @@ def _handle_add_command(app: Application, parser: QCommandLineParser):
     model_size = parse_enum_option(opts["model_size"], parser, WhisperModelSize)
 
     model_path, model = _resolve_model(
-        model_type, model_size, parser.value(opts["hugging_face_model_id"])
+        model_type,
+        model_size,
+        parser.value(opts["hugging_face_model_id"]),
+        parser.value(opts["custom_model_id"]),
     )
 
     language = parser.value(opts["language"])

--- a/buzz/locale/ca_ES/LC_MESSAGES/buzz.po
+++ b/buzz/locale/ca_ES/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: buzz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2025-10-17 07:59+0200\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: Éric Duarte <contacto@ericdq.com>\n"
 "Language-Team: Catalan <jmas@softcatala.org>\n"
 "Language: ca\n"
@@ -84,6 +84,11 @@ msgstr "Danès"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Holandès"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Francés"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -229,6 +234,11 @@ msgid "Disable GPU"
 msgstr "Desactiva la GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Evita que el sistema entri en repòs mentre hi ha transcripcions a la cua"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Prova de clau OpenAI API"
 
@@ -343,6 +353,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "ID de la cara oculta d'un model de whisper més ràpid"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Nom del model personalitzat"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Afegeix un fitxer de model local"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Afegeix un model des d’un URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Descàrrega"
 
@@ -365,6 +387,24 @@ msgstr "Disponible per descarregar"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Enllaç de descàrrega a Whisper.cpp fitxer de model ggml"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Seleccioneu el fitxer de model de Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Model de Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Tots els fitxers"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -722,10 +762,6 @@ msgid "Dark"
 msgstr "Fosc"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Personalitzat"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Color del text"
 
@@ -896,6 +932,14 @@ msgstr "Descàrrega completada!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "No s'ha pogut executar l'instal·lador: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Quant a"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Versió"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1336,10 +1380,6 @@ msgid "Import Folder..."
 msgstr "Importa carpeta..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Quant a"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Preferències..."
 
@@ -1409,10 +1449,6 @@ msgstr "Xinès"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Coreà"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Francés"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2007,15 +2043,10 @@ msgstr "Desa el resum en un fitxer"
 msgid "Output folder (for file)"
 msgstr "Carpeta de sortida (per al fitxer)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Evita que el sistema entri en repòs mentre hi ha transcripcions a la cua"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Ha fallat l'extracció de veu! Comproveu la vostra connexió a Internet — pot "
 "ser que s'hagi de descarregar un model."

--- a/buzz/locale/da_DK/LC_MESSAGES/buzz.po
+++ b/buzz/locale/da_DK/LC_MESSAGES/buzz.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: Ole Guldberg2 <xalt7x.service@gmail.com>\n"
 "Language-Team: \n"
 "Language: da_DK\n"
@@ -82,6 +82,11 @@ msgstr "Dansk"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Nederlandsk"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Fransk"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -226,6 +231,10 @@ msgid "Disable GPU"
 msgstr "Deaktiver GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr "Forhindr systemet i at gå i dvale, når der er transkriptioner i køen"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "OpenAI API Nøgle test"
 
@@ -340,6 +349,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Huggingface ID af Faster Whisper model"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Navn til den brugerdefinerede model"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Tilføj lokal modelfil"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Tilføj model fra URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Download"
 
@@ -362,6 +383,24 @@ msgstr "Tilgængelige til download"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Download link til Whisper.cpp ggml model-fil"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Brugerdefineret"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Vælg Whisper.cpp-modelfil"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cpp-model"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Alle filer"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -677,8 +716,9 @@ msgstr ""
 #: buzz/widgets/transcription_tasks_table_widget.py
 msgid "Could not restart transcription: transcriber worker not found."
 msgstr ""
-"Kunne ikke genstarte transskription: transskriptionsarbejder ikke fundet."
-"Kunne ikke genstarte transkription: transkriptionsprocessen blev ikke fundet."
+"Kunne ikke genstarte transskription: transskriptionsarbejder ikke "
+"fundet.Kunne ikke genstarte transkription: transkriptionsprocessen blev ikke "
+"fundet."
 
 #: buzz/widgets/recording_transcriber_widget.py
 msgid "Live Recording"
@@ -715,10 +755,6 @@ msgstr "Lys"
 #: buzz/widgets/recording_transcriber_widget.py
 msgid "Dark"
 msgstr "Mørk"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Brugerdefineret"
 
 #: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
@@ -891,6 +927,14 @@ msgstr "Download fuldført!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Kunne ikke køre installationsprogrammet: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Om"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Version"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1328,10 +1372,6 @@ msgid "Import Folder..."
 msgstr "Importer Mappe..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Om"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Indstillinger..."
 
@@ -1398,10 +1438,6 @@ msgstr "Kinesisk"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Koreansk"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Fransk"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1944,8 +1980,8 @@ msgid ""
 "Skip if a .txt, .srt, or .vtt file matching the audio filename is found next "
 "to it"
 msgstr ""
-"Spring over, hvis der ved siden af lydfilen ligger en .txt-, .srt- eller ."
-"vtt-fil med samme navn"
+"Spring over, hvis der ved siden af lydfilen ligger en .txt-, .srt- "
+"eller .vtt-fil med samme navn"
 
 #: buzz/plugins/skip_already_transcribed/plugin.py
 msgid "Check in transcription database"
@@ -1995,15 +2031,10 @@ msgstr "Gem resumé i en fil"
 msgid "Output folder (for file)"
 msgstr "Outputmappe (til fil)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Forhindr systemet i at gå i dvale, når der er transkriptioner i køen"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Taleoprydning mislykkedes! Kontroller din internetforbindelse — en model "
 "skal muligvis hentes ned."

--- a/buzz/locale/de_DE/LC_MESSAGES/buzz.po
+++ b/buzz/locale/de_DE/LC_MESSAGES/buzz.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2025-03-05 14:41+0100\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de_DE@formal\n"
@@ -83,6 +83,11 @@ msgstr "Dänisch"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Niederländisch"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Französisch"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -228,6 +233,12 @@ msgid "Disable GPU"
 msgstr "GPU deaktivieren"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Ruhezustand des Systems verhindern, solange Transkriptionen in der "
+"Warteschlange sind"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "OpenAI-API-Schlüssel Test"
 
@@ -343,6 +354,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Huggingface-ID eines Faster Whisper-Modells"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Name für das benutzerdefinierte Modell"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Lokale Modelldatei hinzufügen"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Modell von URL hinzufügen"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Herunterladen"
 
@@ -365,6 +388,24 @@ msgstr "Zum Herunterladen verfügbar"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Laden Sie den Link zur ggml-Modelldatei Whisper.cpp herunter"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Whisper.cpp-Modelldatei auswählen"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cpp-Modell"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Alle Dateien"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -723,10 +764,6 @@ msgid "Dark"
 msgstr "Dunkel"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Textfarbe"
 
@@ -897,6 +934,14 @@ msgstr "Download abgeschlossen!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Installer konnte nicht ausgeführt werden: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Über"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Version"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1341,10 +1386,6 @@ msgid "Import Folder..."
 msgstr "Ordner importieren..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Über"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Einstellungen..."
 
@@ -1386,9 +1427,9 @@ msgstr ""
 #: buzz/transcriber/recording_transcriber.py
 msgid "Whisper server failed to start. Check logs for details."
 msgstr ""
-"Whisper-Server konnte nicht gestartet werden. Protokolle für Details prüfen."
-"Whisper-Server konnte nicht gestartet werden. Details in den Protokollen "
-"prüfen."
+"Whisper-Server konnte nicht gestartet werden. Protokolle für Details "
+"prüfen.Whisper-Server konnte nicht gestartet werden. Details in den "
+"Protokollen prüfen."
 
 #: buzz/transcriber/local_whisper_cpp_server_transcriber.py
 #: buzz/transcriber/recording_transcriber.py
@@ -1417,10 +1458,6 @@ msgstr "Chinesisch"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Koreanisch"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Französisch"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2016,15 +2053,10 @@ msgstr "Zusammenfassung in einer Datei speichern"
 msgid "Output folder (for file)"
 msgstr "Ausgabeordner (für Datei)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Ruhezustand des Systems verhindern, solange Transkriptionen in der Warteschlange sind"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Sprachextraktion fehlgeschlagen! Bitte Internetverbindung prüfen — ein "
 "Modell muss möglicherweise heruntergeladen werden."

--- a/buzz/locale/en_US/LC_MESSAGES/buzz.po
+++ b/buzz/locale/en_US/LC_MESSAGES/buzz.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,6 +83,11 @@ msgstr ""
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
 msgstr ""
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
@@ -221,6 +226,10 @@ msgid "Disable GPU"
 msgstr ""
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr ""
 
@@ -325,6 +334,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr ""
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr ""
 
@@ -346,6 +367,24 @@ msgstr ""
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr ""
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
 msgstr ""
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
@@ -688,10 +727,6 @@ msgid "Dark"
 msgstr ""
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr ""
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr ""
 
@@ -855,6 +890,14 @@ msgstr ""
 
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
+msgstr ""
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr ""
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
 msgstr ""
 
 #: buzz/widgets/about_dialog.py
@@ -1279,10 +1322,6 @@ msgid "Import Folder..."
 msgstr ""
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr ""
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr ""
 
@@ -1343,10 +1382,6 @@ msgstr ""
 
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
-msgstr ""
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
 msgstr ""
 
 #: buzz/transcriber/transcriber.py
@@ -1922,12 +1957,8 @@ msgstr ""
 msgid "Output folder (for file)"
 msgstr ""
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""

--- a/buzz/locale/es_ES/LC_MESSAGES/buzz.po
+++ b/buzz/locale/es_ES/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2025-09-08 12:43+0200\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: Éric Duarte <contacto@ericdq.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -85,6 +85,11 @@ msgstr "Danés"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Holandés"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Francés"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -233,6 +238,12 @@ msgid "Disable GPU"
 msgstr "Desactivar GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Evitar que el sistema entre en suspensión mientras haya transcripciones en "
+"cola"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Prueba de la clave API de OpenAI"
 
@@ -350,6 +361,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Identificación de un modelo Más rápido whisper"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Nombre del modelo personalizado"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Añadir archivo de modelo local"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Añadir modelo desde URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Descargar"
 
@@ -372,6 +395,24 @@ msgstr "Disponible para descarga"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Enlace de descarga a Whisper.cpp archivo de modelo ggml"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Personalizado"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Seleccione el archivo de modelo de Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Modelo de Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Todos los archivos"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -753,10 +794,6 @@ msgid "Dark"
 msgstr "Oscuro"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Personalizado"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Color del texto"
 
@@ -930,6 +967,14 @@ msgstr "¡Descarga completa!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "No se pudo ejecutar el instalador: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Acerca de"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Versión"
 
 # automatic translation
 #: buzz/widgets/about_dialog.py
@@ -1381,10 +1426,6 @@ msgstr "Importar URL..."
 msgid "Import Folder..."
 msgstr "Importar carpeta..."
 
-#: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Acerca de"
-
 # automatic translation
 #: buzz/widgets/menu_bar.py
 msgid "Preferences..."
@@ -1462,10 +1503,6 @@ msgstr "China"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Coreano"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Francés"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2069,15 +2106,10 @@ msgstr "Guardar resumen en un archivo"
 msgid "Output folder (for file)"
 msgstr "Carpeta de salida (para el archivo)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Evitar que el sistema entre en suspensión mientras haya transcripciones en cola"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "¡Extracción de voz fallida! Compruebe su conexión a internet — es posible "
 "que sea necesario descargar un modelo."

--- a/buzz/locale/fr/LC_MESSAGES/buzz.po
+++ b/buzz/locale/fr/LC_MESSAGES/buzz.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 18:45+0200\n"
-"PO-Revision-Date: 2026-08-27 19:23+0200\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: cherkaba\n"
 "Language-Team: French <kde-francophone@kde.org>\n"
 "Language: fr\n"
@@ -20,482 +20,53 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.9\n"
 
-#: buzz/settings/recording_transcriber_mode.py
-msgid "Append below"
-msgstr "Ajouter en dessous"
-
-#: buzz/settings/recording_transcriber_mode.py
-msgid "Append above"
-msgstr "Ajouter au-dessus"
-
-#: buzz/settings/recording_transcriber_mode.py
-msgid "Append and correct"
-msgstr "Ajouter et corriger"
-
-#: buzz/settings/shortcut.py
-msgid "Open Record Window"
-msgstr "Ouvrir la fenêtre d'enregistrement"
-
-#: buzz/settings/shortcut.py
-msgid "Import File"
-msgstr "Importer un fichier"
-
-#: buzz/settings/shortcut.py buzz/widgets/import_url_dialog.py
+#: buzz/widgets/import_url_dialog.py buzz/settings/shortcut.py
 msgid "Import URL"
 msgstr "Importer une URL"
 
-#: buzz/settings/shortcut.py
-msgid "Open Preferences Window"
-msgstr "Ouvrir les préférences"
-
-#: buzz/settings/shortcut.py
-msgid "View Transcript Text"
-msgstr "Afficher le texte de la transcription"
-
-#: buzz/settings/shortcut.py
-msgid "View Transcript Translation"
-msgstr "Afficher la traduction de la transcription"
-
-#: buzz/settings/shortcut.py
-msgid "View Transcript Timestamps"
-msgstr "Afficher les horodatages de la transcription"
-
-#: buzz/settings/shortcut.py
-msgid "Search Transcript"
-msgstr "Rechercher dans la transcription"
-
-#: buzz/settings/shortcut.py
-msgid "Go to Next Transcript Search Result"
-msgstr "Résultat suivant de la recherche"
-
-#: buzz/settings/shortcut.py
-msgid "Go to Previous Transcript Search Result"
-msgstr "Résultat précédent de la recherche"
-
-#: buzz/settings/shortcut.py
-msgid "Scroll to Current Text"
-msgstr "Faire défiler jusqu'au texte actuel"
-
-#: buzz/settings/shortcut.py
-msgid "Play/Pause Audio"
-msgstr "Lecture / Pause"
-
-#: buzz/settings/shortcut.py
-msgid "Replay Current Segment"
-msgstr "Rejouer le segment actuel"
-
-#: buzz/settings/shortcut.py
-msgid "Toggle Playback Controls"
-msgstr "Afficher / Masquer les contrôles de lecture"
-
-#: buzz/settings/shortcut.py
-msgid "Decrease Segment Start Time"
-msgstr "Diminuer le début du segment"
-
-#: buzz/settings/shortcut.py
-msgid "Increase Segment Start Time"
-msgstr "Augmenter le début du segment"
-
-#: buzz/settings/shortcut.py
-msgid "Decrease Segment End Time"
-msgstr "Diminuer la fin du segment"
-
-#: buzz/settings/shortcut.py
-msgid "Increase Segment End Time"
-msgstr "Augmenter la fin du segment"
-
-#: buzz/settings/shortcut.py buzz/widgets/main_window_toolbar.py
-#: buzz/widgets/main_window.py
-msgid "Clear History"
-msgstr "Effacer l'historique"
-
-#: buzz/settings/shortcut.py buzz/widgets/main_window_toolbar.py
-msgid "Cancel Transcription"
-msgstr "Annuler la transcription"
-
-#: buzz/file_transcriber_queue_worker.py
-msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
-msgstr ""
-"L'extraction de la parole a échoué ! Vérifiez votre connexion internet — un "
-"modèle doit peut-être être téléchargé."
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "AI Summary"
-msgstr "Résumé IA"
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid ""
-"Generate an AI summary of the transcript via an OpenAI-compatible API and "
-"save it to the Notes field and/or a file."
-msgstr ""
-"Générer un résumé IA de la transcription via une API compatible OpenAI et le "
-"sauvegarder dans le champ Notes et/ou dans un fichier."
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "API base URL"
-msgstr "URL de base de l'API"
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "API key"
-msgstr "Clé API"
-
-#: buzz/plugins/ai_summary/plugin.py
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Model"
-msgstr "Modèle"
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "Summarization prompt"
-msgstr "Invite de résumé"
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "Save summary to Notes"
-msgstr "Sauvegarder le résumé dans les Notes"
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "Save summary to a file"
-msgstr "Sauvegarder le résumé dans un fichier"
-
-#: buzz/plugins/ai_summary/plugin.py
-msgid "Output folder (for file)"
-msgstr "Dossier de sortie (pour le fichier)"
-
-#: buzz/plugins/ai_summary/plugin.py buzz/plugins/export_docx/plugin.py
-msgid "Leave empty to save next to the source file."
-msgstr "Laisser vide pour sauvegarder à côté du fichier source."
-
-#: buzz/plugins/skip_already_transcribed/plugin.py
-msgid "Skip Already Transcribed"
-msgstr "Ignorer les déjà transcrits"
-
-#: buzz/plugins/skip_already_transcribed/plugin.py
-msgid "Skip transcription if results already exist on disk or in the database"
-msgstr ""
-"Ignorer la transcription si les résultats existent déjà sur le disque ou dans "
-"la base de données"
-
-#: buzz/plugins/skip_already_transcribed/plugin.py
-msgid "Check for existing result files"
-msgstr "Vérifier les fichiers de résultats existants"
-
-#: buzz/plugins/skip_already_transcribed/plugin.py
-msgid ""
-"Skip if a .txt, .srt, or .vtt file matching the audio filename is found next "
-"to it"
-msgstr ""
-"Ignorer si un fichier .txt, .srt ou .vtt correspondant au fichier audio est "
-"trouvé à côté"
-
-#: buzz/plugins/skip_already_transcribed/plugin.py
-msgid "Check in transcription database"
-msgstr "Vérifier dans la base de données des transcriptions"
-
-#: buzz/plugins/skip_already_transcribed/plugin.py
-msgid ""
-"Skip if this file has already been transcribed and the record exists in the "
-"database"
-msgstr ""
-"Ignorer si ce fichier a déjà été transcrit et que l'enregistrement existe "
-"dans la base de données"
-
-#: buzz/plugins/deep_filter_net/plugin.py
-msgid "DeepFilterNet Noise Reduction"
-msgstr "Réduction du bruit DeepFilterNet"
-
-#: buzz/plugins/deep_filter_net/plugin.py
-msgid "Removes background noise using DeepFilterNet3 before transcription."
-msgstr ""
-"Supprime le bruit de fond en utilisant DeepFilterNet3 avant la transcription."
-
-#: buzz/plugins/deep_filter_net/plugin.py
-msgid "Keep denoised file after transcription"
-msgstr "Conserver le fichier débruité après la transcription"
-
-#: buzz/plugins/enhanced_language_detection/plugin.py
-msgid "Enhanced language detection"
-msgstr "Détection de langue améliorée"
-
-#: buzz/plugins/enhanced_language_detection/plugin.py
-msgid ""
-"Detect the spoken language with whisper.cpp before transcription (using the "
-"largest downloaded model, or the tiny model otherwise) and use it for the "
-"transcription and exported file names. Only runs when the language is set to "
-"auto-detect."
-msgstr ""
-"Détecte la langue parlée avec whisper.cpp avant la transcription (en "
-"utilisant le plus gros modèle téléchargé, ou le modèle 'tiny' sinon) et "
-"l'utilise pour la transcription et les noms de fichiers exportés. Ne "
-"s'exécute que lorsque la langue est réglée sur 'Détection automatique'."
-
-#: buzz/plugins/enhanced_language_detection/plugin.py
-msgid "Download tiny model if none available"
-msgstr "Télécharger le modèle 'tiny' si aucun n'est disponible"
-
-#: buzz/plugins/enhanced_language_detection/plugin.py
-msgid ""
-"If no whisper.cpp model is downloaded, download the tiny model to use for "
-"language detection."
-msgstr ""
-"Si aucun modèle whisper.cpp n'est téléchargé, télécharge le modèle 'tiny' "
-"pour la détection de la langue."
-
-#: buzz/plugins/export_docx/plugin.py
-msgid "Export to DOCX"
-msgstr "Exporter en DOCX"
-
-#: buzz/plugins/export_docx/plugin.py
-msgid ""
-"Export the transcript to a Microsoft Word (.docx) file after transcription, "
-"optionally including timestamps."
-msgstr ""
-"Exporter la transcription vers un fichier Microsoft Word (.docx) après la "
-"transcription, avec la possibilité d'inclure des horodatages."
-
-#: buzz/plugins/export_docx/plugin.py
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid "Output folder"
-msgstr "Dossier de sortie"
-
-#: buzz/plugins/export_docx/plugin.py
-msgid "Include timestamps"
-msgstr "Inclure les horodatages"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-msgid "Automatic Transcript Resizer"
-msgstr "Redimensionneur automatique de transcription"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-msgid ""
-"When a transcription has word-level timings, automatically regroup the words "
-"into properly sized subtitles and replace the result. Mirrors the Merge "
-"options of the transcript resizer."
-msgstr ""
-"Lorsqu'une transcription dispose d'horodatages au niveau des mots, regroupe "
-"automatiquement les mots en sous-titres de taille appropriée et remplace le "
-"résultat. Reflète les options de Fusion du redimensionneur de transcription."
-
-#: buzz/plugins/transcript_resizer/plugin.py
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Merge by gap"
-msgstr "Fusionner par espace"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-msgid "Merge gap (seconds)"
-msgstr "Espace de fusion (secondes)"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Split by punctuation"
-msgstr "Diviser par ponctuation"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-msgid "Punctuation"
-msgstr "Ponctuation"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Split by max length"
-msgstr "Diviser par longueur max"
-
-#: buzz/plugins/transcript_resizer/plugin.py
-msgid "Maximum subtitle length"
-msgstr "Longueur max des sous-titres"
-
-#: buzz/model_loader.py
-msgid "Custom model URL is not provided"
-msgstr "L'URL du modèle personnalisé n'est pas fournie"
-
-#: buzz/model_loader.py buzz/widgets/main_window.py
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-#: buzz/widgets/update_dialog.py
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Error"
-msgstr "Erreur"
-
-#: buzz/model_loader.py buzz/transcriber/recording_transcriber.py
-msgid "A connection error occurred"
-msgstr "Une erreur de connexion est survenue"
-
-#: buzz/widgets/main_window_toolbar.py buzz/widgets/record_button.py
-msgid "Record"
-msgstr "Enregistrer"
-
-#: buzz/widgets/main_window_toolbar.py
-msgid "New File Transcription"
-msgstr "Nouvelle transcription de fichier"
-
-#: buzz/widgets/main_window_toolbar.py
-msgid "New URL Transcription"
-msgstr "Nouvelle transcription d'URL"
-
-#: buzz/widgets/main_window_toolbar.py
-msgid "Open Transcript"
-msgstr "Ouvrir une transcription"
-
-#: buzz/widgets/main_window_toolbar.py buzz/widgets/update_dialog.py
-msgid "Update Available"
-msgstr "Mise à jour disponible"
-
-#: buzz/widgets/main_window.py
-msgid ""
-"Are you sure you want to delete the selected transcription(s)? This action "
-"cannot be undone."
-msgstr ""
-"Voulez-vous vraiment supprimer la/les transcription(s) sélectionnée(s) ? "
-"Cette action est irréversible."
-
-#: buzz/widgets/main_window.py
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
 #: buzz/widgets/import_url_dialog.py
+msgid "https://example.com/audio.mp3"
+msgstr "https://exemple.com/audio.mp3"
+
+#: buzz/widgets/import_url_dialog.py
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
 #: buzz/widgets/plugins_dialog/plugins_dialog.py
 #: buzz/widgets/plugins_dialog/plugin_settings_dialog.py
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
+#: buzz/widgets/main_window.py
 msgid "Ok"
 msgstr "Ok"
 
-#: buzz/widgets/main_window.py buzz/widgets/model_download_progress_dialog.py
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
-#: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 #: buzz/widgets/import_url_dialog.py
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 #: buzz/widgets/plugins_dialog/plugins_dialog.py
 #: buzz/widgets/plugins_dialog/plugin_settings_dialog.py
+#: buzz/widgets/transcription_viewer/speaker_identification_widget.py
+#: buzz/widgets/model_download_progress_dialog.py buzz/widgets/main_window.py
 msgid "Cancel"
 msgstr "Annuler"
 
-#: buzz/widgets/main_window.py
-msgid "Select audio file"
-msgstr "Sélectionner un fichier audio"
+#: buzz/widgets/import_url_dialog.py
+msgid "URL:"
+msgstr "URL :"
 
-#: buzz/widgets/main_window.py
-msgid "Select folder"
-msgstr "Sélectionner un dossier"
+#: buzz/widgets/import_url_dialog.py
+msgid "Invalid URL"
+msgstr "URL invalide"
 
-#: buzz/widgets/main_window.py
-msgid "Unable to save OpenAI API key to keyring"
-msgstr "Impossible de sauvegarder la clé API OpenAI dans le trousseau"
+#: buzz/widgets/import_url_dialog.py
+msgid "The URL you entered is invalid."
+msgstr "L'URL que vous avez saisie est invalide."
 
-#: buzz/widgets/model_download_progress_dialog.py
-msgid "Downloading model"
-msgstr "Téléchargement du modèle"
-
-#: buzz/widgets/model_download_progress_dialog.py
-msgid "remaining"
-msgstr "restant"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid "Enable folder watch"
-msgstr "Activer la surveillance de dossier"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid "Delete processed files"
-msgstr "Supprimer les fichiers traités"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Browse"
-msgstr "Parcourir"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid "Input folder"
-msgstr "Dossier d'entrée"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid "Select Input Folder"
-msgstr "Sélectionner le dossier d'entrée"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid "Select Output Folder"
-msgstr "Sélectionner le dossier de sortie"
-
-#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
-msgid ""
-"The output folder cannot be the input folder or a subfolder of it. This would "
-"cause transcriptions to be processed repeatedly. Please choose a different "
-"output folder."
-msgstr ""
-"Le dossier de sortie ne peut pas être le dossier d'entrée ou un sous-dossier "
-"de celui-ci. Cela entraînerait un traitement répété des transcriptions. "
-"Veuillez choisir un autre dossier de sortie."
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "What model should I use?"
-msgstr "Quel modèle dois-je utiliser ?"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Group"
-msgstr "Groupe"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Huggingface ID of a Faster whisper model"
-msgstr "ID Huggingface d'un modèle Faster Whisper"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Download"
-msgstr "Télécharger"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Show file location"
-msgstr "Afficher l'emplacement du fichier"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Delete"
-msgstr "Supprimer"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Downloaded"
-msgstr "Téléchargé"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Available for Download"
-msgstr "Disponible au téléchargement"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Download link to Whisper.cpp ggml model file"
-msgstr "Lien de téléchargement pour le fichier de modèle Whisper.cpp ggml"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Delete Model"
-msgstr "Supprimer le modèle"
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Are you sure you want to delete the selected model?"
-msgstr ""
-"Voulez-vous vraiment supprimer le modèle sélectionné ? Cette action est "
-"irréversible."
-
-#: buzz/widgets/preferences_dialog/models_preferences_widget.py
-msgid "Download failed"
-msgstr "Échec du téléchargement"
+#: buzz/widgets/presentation_window.py
+msgid "Live Transcript Presentation"
+msgstr "Présentation de la transcription en direct"
 
 #: buzz/widgets/preferences_dialog/shortcuts_editor_preferences_widget.py
 msgid "Reset to Defaults"
 msgstr "Rétablir les valeurs par défaut"
-
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
-msgid "Preferences"
-msgstr "Préférences"
-
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
-msgid "General"
-msgstr "Général"
-
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
-msgid "Models"
-msgstr "Modèles"
-
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
-msgid "Shortcuts"
-msgstr "Raccourcis"
-
-#: buzz/widgets/preferences_dialog/preferences_dialog.py
-msgid "Folder Watch"
-msgstr "Surveillance de dossier"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -516,6 +87,11 @@ msgstr "Danois"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Néerlandais"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Français"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -606,6 +182,12 @@ msgid "Enable live recording transcription export"
 msgstr "Activer l'exportation des transcriptions en direct"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Browse"
+msgstr "Parcourir"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "Export folder"
 msgstr "Dossier d'exportation"
 
@@ -633,8 +215,9 @@ msgid ""
 "Applies to Huggingface and Faster Whisper models. Reduces GPU memory usage "
 "but may slightly decrease transcription quality."
 msgstr ""
-"S'applique aux modèles Huggingface et Faster Whisper. Réduit l'utilisation de "
-"la mémoire GPU mais peut légèrement diminuer la qualité de la transcription."
+"S'applique aux modèles Huggingface et Faster Whisper. Réduit l'utilisation "
+"de la mémoire GPU mais peut légèrement diminuer la qualité de la "
+"transcription."
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "Reduce GPU RAM"
@@ -647,8 +230,8 @@ msgstr "Utiliser uniquement le CPU et désactiver l'accélération GPU"
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "Set this if larger models do not fit your GPU memory and Buzz crashes"
 msgstr ""
-"Activez cette option si les modèles plus gros ne tiennent pas dans la mémoire "
-"GPU et que Buzz plante"
+"Activez cette option si les modèles plus gros ne tiennent pas dans la "
+"mémoire GPU et que Buzz plante"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "Disable GPU"
@@ -678,8 +261,8 @@ msgstr "Clé API invalide"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid ""
-"API supports only base64 characters (A-Za-z0-9+/=_-). Other characters in API "
-"key may cause errors."
+"API supports only base64 characters (A-Za-z0-9+/=_-). Other characters in "
+"API key may cause errors."
 msgstr ""
 "L'API ne supporte que les caractères base64 (A-Za-z0-9+/=_-). D'autres "
 "caractères dans la clé API peuvent causer des erreurs."
@@ -695,13 +278,614 @@ msgid ""
 "Transcription and translation may still work if the API does not support key "
 "validation."
 msgstr ""
-"L'API OpenAI a renvoyé une réponse invalide. Veuillez vérifier l'URL de l'API "
-"ou votre clé. La transcription et la traduction peuvent encore fonctionner si "
-"l'API ne supporte pas la validation de la clé."
+"L'API OpenAI a renvoyé une réponse invalide. Veuillez vérifier l'URL de "
+"l'API ou votre clé. La transcription et la traduction peuvent encore "
+"fonctionner si l'API ne supporte pas la validation de la clé."
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+msgid "Enable folder watch"
+msgstr "Activer la surveillance de dossier"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+msgid "Delete processed files"
+msgstr "Supprimer les fichiers traités"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+msgid "Input folder"
+msgstr "Dossier d'entrée"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+#: buzz/plugins/export_docx/plugin.py
+msgid "Output folder"
+msgstr "Dossier de sortie"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+msgid "Select Input Folder"
+msgstr "Sélectionner le dossier d'entrée"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+msgid "Select Output Folder"
+msgstr "Sélectionner le dossier de sortie"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcription_tasks_table_widget.py
+#: buzz/widgets/update_dialog.py buzz/widgets/main_window.py
+#: buzz/model_loader.py
+msgid "Error"
+msgstr "Erreur"
+
+#: buzz/widgets/preferences_dialog/folder_watch_preferences_widget.py
+msgid ""
+"The output folder cannot be the input folder or a subfolder of it. This "
+"would cause transcriptions to be processed repeatedly. Please choose a "
+"different output folder."
+msgstr ""
+"Le dossier de sortie ne peut pas être le dossier d'entrée ou un sous-dossier "
+"de celui-ci. Cela entraînerait un traitement répété des transcriptions. "
+"Veuillez choisir un autre dossier de sortie."
+
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+msgid "Preferences"
+msgstr "Préférences"
+
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+msgid "General"
+msgstr "Général"
+
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+msgid "Models"
+msgstr "Modèles"
+
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: buzz/widgets/preferences_dialog/preferences_dialog.py
+msgid "Folder Watch"
+msgstr "Surveillance de dossier"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "What model should I use?"
+msgstr "Quel modèle dois-je utiliser ?"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Group"
+msgstr "Groupe"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Huggingface ID of a Faster whisper model"
+msgstr "ID Huggingface d'un modèle Faster Whisper"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Nom du modèle personnalisé"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Ajouter un fichier de modèle local"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Ajouter un modèle depuis une URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Download"
+msgstr "Télécharger"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Show file location"
+msgstr "Afficher l'emplacement du fichier"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Delete"
+msgstr "Supprimer"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Downloaded"
+msgstr "Téléchargé"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Available for Download"
+msgstr "Disponible au téléchargement"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Download link to Whisper.cpp ggml model file"
+msgstr "Lien de téléchargement pour le fichier de modèle Whisper.cpp ggml"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Sélectionner le fichier de modèle Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Modèle Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Tous les fichiers"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Delete Model"
+msgstr "Supprimer le modèle"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Are you sure you want to delete the selected model?"
+msgstr ""
+"Voulez-vous vraiment supprimer le modèle sélectionné ? Cette action est "
+"irréversible."
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Download failed"
+msgstr "Échec du téléchargement"
+
+#: buzz/widgets/record_button.py buzz/widgets/main_window_toolbar.py
+msgid "Record"
+msgstr "Enregistrer"
 
 #: buzz/widgets/record_button.py
 msgid "Stop"
 msgstr "Arrêter"
+
+#: buzz/widgets/transcriber/languages_combo_box.py
+#: buzz/transcriber/transcriber.py
+msgid "Detect Language"
+msgstr "Détection automatique"
+
+#: buzz/widgets/transcriber/mms_language_line_edit.py
+msgid "e.g., eng, fra, deu"
+msgstr "ex. : eng, fra, deu"
+
+#: buzz/widgets/transcriber/mms_language_line_edit.py
+msgid ""
+"Enter an ISO 639-3 language code (3 letters).\n"
+"Examples: eng (English), fra (French), deu (German),\n"
+"spa (Spanish), lav (Latvian)"
+msgstr ""
+"Saisissez un code de langue ISO 639-3 (3 lettres).\n"
+"Exemples : eng (Anglais), fra (Français), deu (Allemand),\n"
+"spa (Espagnol), lav (Letton)"
+
+#: buzz/widgets/transcriber/file_transcriber_widget.py
+msgid "Run"
+msgstr "Exécuter"
+
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/transcription_viewer/speaker_identification_widget.py
+msgid "Model:"
+msgstr "Modèle :"
+
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/transcriber/recording_transcriber.py
+msgid "First time use of a model may take up to several minutest to load."
+msgstr ""
+"La première utilisation d'un modèle peut prendre plusieurs minutes à charger."
+
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+msgid "Api Key:"
+msgstr "Clé API :"
+
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+msgid "Task:"
+msgstr "Tâche :"
+
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+msgid "Language:"
+msgstr "Langue :"
+
+#: buzz/widgets/transcriber/initial_prompt_text_edit.py
+msgid "Enter prompt..."
+msgstr "Saisissez l'invite..."
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Advanced Settings"
+msgstr "Paramètres avancés"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Speech recognition settings"
+msgstr "Paramètres de reconnaissance vocale"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Initial Prompt:"
+msgstr "Invite initiale :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Translation settings"
+msgstr "Paramètres de traduction"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Enable AI translation"
+msgstr "Activer la traduction IA"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "AI model:"
+msgstr "Modèle IA :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Open documentation for AI translation models"
+msgstr "Ouvrir la documentation des modèles de traduction IA"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid ""
+"Please translate each text sent to you from English to Spanish. Translation "
+"will be used in an automated system, please do not add any comments or "
+"notes, just the translation."
+msgstr ""
+"Veuillez traduire chaque texte reçu de l'anglais vers l'espagnol. La "
+"traduction sera utilisée dans un système automatisé, ne veuillez ajouter "
+"aucun commentaire, juste la traduction."
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Instructions for AI:"
+msgstr "Instructions pour l'IA :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Recording settings"
+msgstr "Paramètres d'enregistrement"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Silence threshold:"
+msgstr "Seuil de silence :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Line separator:"
+msgstr "Séparateur de ligne :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Transcription step:"
+msgstr "Étape de transcription :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Hide unconfirmed"
+msgstr "Masquer les non confirmés"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Enable live recording export"
+msgstr "Activer l'exportation en direct"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Export folder:"
+msgstr "Dossier d'exportation :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Export file name:"
+msgstr "Nom du fichier d'exportation :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Text file (.txt)"
+msgstr "Fichier texte (.txt)"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "CSV (.csv)"
+msgstr "CSV (.csv)"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid "Export file type:"
+msgstr "Type de fichier d'exportation :"
+
+#: buzz/widgets/transcriber/advanced_settings_dialog.py
+msgid ""
+"Limit export entries\n"
+"(0 = export all):"
+msgstr ""
+"Limiter les entrées exportées\n"
+"(0 = tout exporter) :"
+
+#: buzz/widgets/transcriber/file_transcription_form_widget.py
+msgid "Word-level timings"
+msgstr "Horodatages par mot"
+
+#: buzz/widgets/transcriber/file_transcription_form_widget.py
+msgid "Extract speech"
+msgstr "Extraire la parole"
+
+#: buzz/widgets/transcriber/file_transcription_form_widget.py
+msgid "Export:"
+msgstr "Exporter :"
+
+#: buzz/widgets/transcriber/hugging_face_search_line_edit.py
+msgid "Huggingface ID of a model"
+msgstr "ID Huggingface d'un modèle"
+
+#: buzz/widgets/transcriber/advanced_settings_button.py
+msgid "Advanced..."
+msgstr "Avancé..."
+
+#: buzz/widgets/main_window_toolbar.py
+msgid "New File Transcription"
+msgstr "Nouvelle transcription de fichier"
+
+#: buzz/widgets/main_window_toolbar.py
+msgid "New URL Transcription"
+msgstr "Nouvelle transcription d'URL"
+
+#: buzz/widgets/main_window_toolbar.py
+msgid "Open Transcript"
+msgstr "Ouvrir une transcription"
+
+#: buzz/widgets/main_window_toolbar.py buzz/settings/shortcut.py
+msgid "Cancel Transcription"
+msgstr "Annuler la transcription"
+
+#: buzz/widgets/main_window_toolbar.py buzz/widgets/main_window.py
+#: buzz/settings/shortcut.py
+msgid "Clear History"
+msgstr "Effacer l'historique"
+
+#: buzz/widgets/main_window_toolbar.py buzz/widgets/update_dialog.py
+msgid "Update Available"
+msgstr "Mise à jour disponible"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "In Progress"
+msgstr "En cours"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Completed"
+msgstr "Terminé"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Failed"
+msgstr "Échec"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Canceled"
+msgstr "Annulé"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Queued"
+msgstr "En attente"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Skipped"
+msgstr "Ignoré"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "File Name / URL"
+msgstr "Nom du fichier / URL"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+#: buzz/plugins/ai_summary/plugin.py
+msgid "Model"
+msgstr "Modèle"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Task"
+msgstr "Tâche"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Status"
+msgstr "Statut"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Date Completed"
+msgstr "Date d'achèvement"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Date Added"
+msgstr "Date d'ajout"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Notes"
+msgstr "Notes"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Reset Column Order"
+msgstr "Réinitialiser l'ordre des colonnes"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Restart Transcription"
+msgstr "Redémarrer la transcription"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Rename"
+msgstr "Renommer"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Add/Edit Notes"
+msgstr "Ajouter/Modifier les notes"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Rename Transcription"
+msgstr "Renommer la transcription"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Enter new name:"
+msgstr "Entrez un nouveau nom :"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Enter some relevant notes for this transcription:"
+msgstr "Saisissez des notes pertinentes pour cette transcription :"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Cannot Restart"
+msgstr "Impossible de redémarrer"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Only failed, canceled, or skipped transcriptions can be restarted."
+msgstr ""
+"Seules les transcriptions en échec, annulées ou ignorées peuvent être "
+"redémarrées."
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Failed to restart transcription: {}"
+msgstr "Échec du redémarrage de la transcription : {}"
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid ""
+"Could not restart transcription: model not available and could not be "
+"downloaded."
+msgstr ""
+"Impossible de redémarrer la transcription : modèle non disponible et n'a pas "
+"pu être téléchargé."
+
+#: buzz/widgets/transcription_tasks_table_widget.py
+msgid "Could not restart transcription: transcriber worker not found."
+msgstr ""
+"Impossible de redémarrer la transcription : worker du transcripteur "
+"introuvable."
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Live Recording"
+msgstr "Enregistrement en direct"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Click Record to begin..."
+msgstr "Cliquez sur Enregistrer pour commencer..."
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Waiting for AI translation..."
+msgstr "En attente de la traduction IA..."
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Microphone:"
+msgstr "Microphone :"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Show in new window"
+msgstr "Afficher dans une nouvelle fenêtre"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Text Size:"
+msgstr "Taille du texte :"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Theme"
+msgstr "Thème"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Light"
+msgstr "Clair"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Dark"
+msgstr "Sombre"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Text Color"
+msgstr "Couleur du texte"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Background Color"
+msgstr "Couleur d'arrière-plan"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Fullscreen"
+msgstr "Plein écran"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Copy"
+msgstr "Copier"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Copy transcription to clipboard"
+msgstr "Copier la transcription dans le presse-papiers"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Nothing to copy!"
+msgstr "Rien à copier !"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Copy failed"
+msgstr "Échec de la copie"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Copied!"
+msgstr "Copié !"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Select Text Color"
+msgstr "Sélectionner une couleur de texte"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Select Background Color"
+msgstr "Sélectionner une couleur d'arrière-plan"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "An error occurred while starting a new recording:"
+msgstr "Une erreur est survenue lors du lancement d'un nouvel enregistrement :"
+
+#: buzz/widgets/recording_transcriber_widget.py
+msgid ""
+"Please check your audio devices or check the application logs for more "
+"information."
+msgstr ""
+"Veuillez vérifier vos périphériques audio ou consulter les journaux de "
+"l'application pour plus d'informations."
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Plugins"
+msgstr "Modules"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid ""
+"Plugins run with full access to your system. Only install plugins from "
+"sources you trust."
+msgstr ""
+"Les modules disposent d'un accès complet à votre système. N'installez que "
+"des modules provenant de sources de confiance."
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Add by URL..."
+msgstr "Ajouter par URL..."
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Settings..."
+msgstr "Paramètres..."
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Move Up"
+msgstr "Déplacer vers le haut"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Move Down"
+msgstr "Déplacer vers le bas"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Remove"
+msgstr "Retirer"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Remove plugin"
+msgstr "Supprimer le module"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Remove plugin '{}'?"
+msgstr "Supprimer le module '{}' ?"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Add plugin"
+msgstr "Ajouter un module"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Plugin URL (.zip):"
+msgstr "URL du module (.zip) :"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Installing plugin..."
+msgstr "Installation du module..."
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid "Add plugin failed"
+msgstr "Échec de l'ajout du module"
+
+#: buzz/widgets/plugins_dialog/plugins_dialog.py
+msgid ""
+"Could not install the plugin:\n"
+"{}"
+msgstr ""
+"Impossible d'installer le module :\n"
+"{}"
+
+#: buzz/widgets/plugins_dialog/plugin_settings_dialog.py
+msgid "Plugin not available."
+msgstr "Module non disponible."
 
 #: buzz/widgets/update_dialog.py
 msgid "A new version of Buzz is available!"
@@ -728,12 +912,10 @@ msgid "No download URL available for your platform."
 msgstr "Aucune URL de téléchargement disponible pour votre plateforme."
 
 #: buzz/widgets/update_dialog.py
-#, python-brace-format
 msgid "Downloading file {} of {}..."
 msgstr "Téléchargement du fichier {} sur {}..."
 
 #: buzz/widgets/update_dialog.py
-#, python-brace-format
 msgid "Downloading file {} of {} ({:.1f} MB / {:.1f} MB)..."
 msgstr "Téléchargement du fichier {} sur {} ({:.1f} Mo / {:.1f} Mo)..."
 
@@ -742,12 +924,10 @@ msgid "Download Failed"
 msgstr "Échec du téléchargement"
 
 #: buzz/widgets/update_dialog.py
-#, python-brace-format
 msgid "Failed to download the update: {}"
 msgstr "Échec du téléchargement de la mise à jour : {}"
 
 #: buzz/widgets/update_dialog.py
-#, python-brace-format
 msgid "Failed to save the installer: {}"
 msgstr "Échec de l'enregistrement de l'installeur : {}"
 
@@ -756,9 +936,106 @@ msgid "Download complete!"
 msgstr "Téléchargement terminé !"
 
 #: buzz/widgets/update_dialog.py
-#, python-brace-format
 msgid "Failed to run the installer: {}"
 msgstr "Échec de l'exécution de l'installeur : {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "À propos"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Version"
+
+#: buzz/widgets/about_dialog.py
+msgid "Check for updates"
+msgstr "Vérifier les mises à jour"
+
+#: buzz/widgets/about_dialog.py
+msgid "Show logs"
+msgstr "Afficher les journaux"
+
+#: buzz/widgets/about_dialog.py
+msgid "You're up to date!"
+msgstr "Vous êtes à jour !"
+
+#: buzz/widgets/audio_meter_widget.py
+msgid "Average volume"
+msgstr "Volume moyen"
+
+#: buzz/widgets/audio_meter_widget.py
+msgid "Queue"
+msgstr "File d'attente"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Unassigned"
+msgstr "Non assigné"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Choose an identified speaker or type a new speaker name."
+msgstr "Choisissez un intervenant identifié ou saisissez un nouveau nom."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Start"
+msgstr "Début"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "End"
+msgstr "Fin"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker"
+msgstr "Intervenant"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Text"
+msgstr "Texte"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Translation"
+msgstr "Traduction"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid ""
+"Double-click to edit. Select multiple rows and right-click to assign "
+"speakers."
+msgstr ""
+"Double-cliquez pour modifier. Sélectionnez plusieurs lignes et utilisez le "
+"clic droit pour assigner des intervenants."
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Assign Speaker"
+msgstr "Assigner un intervenant"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker…"
+msgstr "Nouvel intervenant…"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "New Speaker"
+msgstr "Nouvel intervenant"
+
+#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
+msgid "Speaker name:"
+msgstr "Nom de l'intervenant :"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "View"
+msgstr "Affichage"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Timestamps"
+msgstr "Horodatages"
+
+#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
+msgid "Speakers"
+msgstr "Intervenants"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "Speaker:"
@@ -872,12 +1149,6 @@ msgid "All speakers"
 msgstr "Tous les intervenants"
 
 #: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Unassigned"
-msgstr "Non assigné"
-
-#: buzz/widgets/transcription_viewer/transcription_viewer_widget.py
 msgid "No segments for this speaker."
 msgstr "Aucun segment pour cet intervenant."
 
@@ -889,41 +1160,68 @@ msgstr "Clé API requise"
 msgid "Please enter OpenAI API Key in preferences"
 msgstr "Veuillez entrer une clé API OpenAI dans les préférences"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Text"
-msgstr "Texte"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Settings"
+msgstr "Paramètres"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Translation"
-msgstr "Traduction"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Create new transcript"
+msgstr "Créer une nouvelle transcription"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-msgid "DOCX – Speakers"
-msgstr "DOCX – Intervenants"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Extend end time"
+msgstr "Prolonger la durée de fin"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-msgid "Save File"
-msgstr "Sauvegarder le fichier"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Extend endings by up to (seconds)"
+msgstr "Prolonger la fin jusqu'à (secondes)"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-msgid "Text files"
-msgstr "Fichiers texte"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Extend endings"
+msgstr "Prolonger les fins"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-msgid "Include timestamps for each speaker turn?"
-msgstr "Inclure les horodatages pour chaque intervention ?"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Resize Options"
+msgstr "Options de redimensionnement"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-msgid "Word documents"
-msgstr "Documents Word"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Desired subtitle length"
+msgstr "Durée souhaitée des sous-titres"
 
-#: buzz/widgets/transcription_viewer/export_transcription_menu.py
-msgid "Export Failed"
-msgstr "Échec de l'exportation"
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Available only if word level timings were disabled during transcription"
+msgstr ""
+"Disponible uniquement si les horodatages par mot ont été désactivés lors de "
+"la transcription"
+
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Merge Options"
+msgstr "Options de fusion"
+
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Merge by gap"
+msgstr "Fusionner par espace"
+
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Split by punctuation"
+msgstr "Diviser par ponctuation"
+
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Split by max length"
+msgstr "Diviser par longueur max"
+
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Merge"
+msgstr "Fusionner"
+
+#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
+msgid "Available only if word level timings were enabled during transcription"
+msgstr ""
+"Disponible uniquement si les horodatages par mot ont été activés lors de la "
+"transcription"
 
 #: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 msgid "3/8 Loading alignment model (retrying with cache...)"
@@ -931,11 +1229,11 @@ msgstr "3/8 Chargement du modèle d'alignement (nouvel essai avec le cache...)"
 
 #: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 msgid ""
-"Failed to load alignment model. Please check your internet connection and try "
-"again."
+"Failed to load alignment model. Please check your internet connection and "
+"try again."
 msgstr ""
-"Échec du chargement du modèle d'alignement. Veuillez vérifier votre connexion "
-"internet et réessayer."
+"Échec du chargement du modèle d'alignement. Veuillez vérifier votre "
+"connexion internet et réessayer."
 
 #: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 msgid "0/0 Error identifying speakers"
@@ -997,11 +1295,6 @@ msgid "Audio file not found"
 msgstr "Fichier audio introuvable"
 
 #: buzz/widgets/transcription_viewer/speaker_identification_widget.py
-#: buzz/widgets/transcriber/transcription_options_group_box.py
-msgid "Model:"
-msgstr "Modèle :"
-
-#: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 msgid "MSDD"
 msgstr "MSDD"
 
@@ -1020,7 +1313,8 @@ msgstr "Automatique"
 #: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 msgid "Set the known number of speakers, or use Auto to detect it."
 msgstr ""
-"Définissez le nombre connu d'intervenants ou utilisez 'Auto' pour le détecter."
+"Définissez le nombre connu d'intervenants ou utilisez 'Auto' pour le "
+"détecter."
 
 #: buzz/widgets/transcription_viewer/speaker_identification_widget.py
 msgid "Step 2: Name speakers"
@@ -1046,578 +1340,37 @@ msgstr "Annulation en cours..."
 msgid "Cancelled"
 msgstr "Annulé"
 
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Settings"
-msgstr "Paramètres"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Create new transcript"
-msgstr "Créer une nouvelle transcription"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Extend end time"
-msgstr "Prolonger la durée de fin"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Extend endings by up to (seconds)"
-msgstr "Prolonger la fin jusqu'à (secondes)"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Extend endings"
-msgstr "Prolonger les fins"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Resize Options"
-msgstr "Options de redimensionnement"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Desired subtitle length"
-msgstr "Durée souhaitée des sous-titres"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Available only if word level timings were disabled during transcription"
-msgstr ""
-"Disponible uniquement si les horodatages par mot ont été désactivés lors de "
-"la transcription"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Merge Options"
-msgstr "Options de fusion"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Merge"
-msgstr "Fusionner"
-
-#: buzz/widgets/transcription_viewer/transcription_resizer_widget.py
-msgid "Available only if word level timings were enabled during transcription"
-msgstr ""
-"Disponible uniquement si les horodatages par mot ont été activés lors de la "
-"transcription"
-
-#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
-msgid "View"
-msgstr "Affichage"
-
-#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
-msgid "Timestamps"
-msgstr "Horodatages"
-
-#: buzz/widgets/transcription_viewer/transcription_view_mode_tool_button.py
-msgid "Speakers"
-msgstr "Intervenants"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Choose an identified speaker or type a new speaker name."
-msgstr "Choisissez un intervenant identifié ou saisissez un nouveau nom."
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Start"
-msgstr "Début"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "End"
-msgstr "Fin"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Speaker"
-msgstr "Intervenant"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid ""
-"Double-click to edit. Select multiple rows and right-click to assign speakers."
-msgstr ""
-"Double-cliquez pour modifier. Sélectionnez plusieurs lignes et utilisez le "
-"clic droit pour assigner des intervenants."
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Assign Speaker"
-msgstr "Assigner un intervenant"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "New Speaker…"
-msgstr "Nouvel intervenant…"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "New Speaker"
-msgstr "Nouvel intervenant"
-
-#: buzz/widgets/transcription_viewer/transcription_segments_editor_widget.py
-msgid "Speaker name:"
-msgstr "Nom de l'intervenant :"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "In Progress"
-msgstr "En cours"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Completed"
-msgstr "Terminé"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Failed"
-msgstr "Échec"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Canceled"
-msgstr "Annulé"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Queued"
-msgstr "En attente"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Skipped"
-msgstr "Ignoré"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "File Name / URL"
-msgstr "Nom du fichier / URL"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Task"
-msgstr "Tâche"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Status"
-msgstr "Statut"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Date Completed"
-msgstr "Date d'achèvement"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Date Added"
-msgstr "Date d'ajout"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Notes"
-msgstr "Notes"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Reset Column Order"
-msgstr "Réinitialiser l'ordre des colonnes"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Restart Transcription"
-msgstr "Redémarrer la transcription"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Rename"
-msgstr "Renommer"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Add/Edit Notes"
-msgstr "Ajouter/Modifier les notes"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Rename Transcription"
-msgstr "Renommer la transcription"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Enter new name:"
-msgstr "Entrez un nouveau nom :"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Enter some relevant notes for this transcription:"
-msgstr "Saisissez des notes pertinentes pour cette transcription :"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Cannot Restart"
-msgstr "Impossible de redémarrer"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Only failed, canceled, or skipped transcriptions can be restarted."
-msgstr ""
-"Seules les transcriptions en échec, annulées ou ignorées peuvent être "
-"redémarrées."
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-#, python-brace-format
-msgid "Failed to restart transcription: {}"
-msgstr "Échec du redémarrage de la transcription : {}"
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid ""
-"Could not restart transcription: model not available and could not be "
-"downloaded."
-msgstr ""
-"Impossible de redémarrer la transcription : modèle non disponible et n'a pas "
-"pu être téléchargé."
-
-#: buzz/widgets/transcription_tasks_table_widget.py
-msgid "Could not restart transcription: transcriber worker not found."
-msgstr ""
-"Impossible de redémarrer la transcription : worker du transcripteur "
-"introuvable."
-
-#: buzz/widgets/audio_meter_widget.py
-msgid "Average volume"
-msgstr "Volume moyen"
-
-#: buzz/widgets/audio_meter_widget.py
-msgid "Queue"
-msgstr "File d'attente"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Live Recording"
-msgstr "Enregistrement en direct"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Click Record to begin..."
-msgstr "Cliquez sur Enregistrer pour commencer..."
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Waiting for AI translation..."
-msgstr "En attente de la traduction IA..."
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Microphone:"
-msgstr "Microphone :"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Show in new window"
-msgstr "Afficher dans une nouvelle fenêtre"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Text Size:"
-msgstr "Taille du texte :"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Theme"
-msgstr "Thème"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Light"
-msgstr "Clair"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Dark"
-msgstr "Sombre"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Personnalisé"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Text Color"
-msgstr "Couleur du texte"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Background Color"
-msgstr "Couleur d'arrière-plan"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Fullscreen"
-msgstr "Plein écran"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Copy"
-msgstr "Copier"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Copy transcription to clipboard"
-msgstr "Copier la transcription dans le presse-papiers"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Nothing to copy!"
-msgstr "Rien à copier !"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Copy failed"
-msgstr "Échec de la copie"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Copied!"
-msgstr "Copié !"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Select Text Color"
-msgstr "Sélectionner une couleur de texte"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Select Background Color"
-msgstr "Sélectionner une couleur d'arrière-plan"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "An error occurred while starting a new recording:"
-msgstr "Une erreur est survenue lors du lancement d'un nouvel enregistrement :"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid ""
-"Please check your audio devices or check the application logs for more "
-"information."
-msgstr ""
-"Veuillez vérifier vos périphériques audio ou consulter les journaux de "
-"l'application pour plus d'informations."
-
-#: buzz/widgets/import_url_dialog.py
-msgid "https://example.com/audio.mp3"
-msgstr "https://exemple.com/audio.mp3"
-
-#: buzz/widgets/import_url_dialog.py
-msgid "URL:"
-msgstr "URL :"
-
-#: buzz/widgets/import_url_dialog.py
-msgid "Invalid URL"
-msgstr "URL invalide"
-
-#: buzz/widgets/import_url_dialog.py
-msgid "The URL you entered is invalid."
-msgstr "L'URL que vous avez saisie est invalide."
-
-#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "À propos"
-
-#: buzz/widgets/about_dialog.py
-msgid "Version"
-msgstr "Version"
-
-#: buzz/widgets/about_dialog.py
-msgid "Check for updates"
-msgstr "Vérifier les mises à jour"
-
-#: buzz/widgets/about_dialog.py
-msgid "Show logs"
-msgstr "Afficher les journaux"
-
-#: buzz/widgets/about_dialog.py
-msgid "You're up to date!"
-msgstr "Vous êtes à jour !"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Plugins"
-msgstr "Modules"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid ""
-"Plugins run with full access to your system. Only install plugins from "
-"sources you trust."
-msgstr ""
-"Les modules disposent d'un accès complet à votre système. N'installez que des "
-"modules provenant de sources de confiance."
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Add by URL..."
-msgstr "Ajouter par URL..."
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Settings..."
-msgstr "Paramètres..."
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Move Up"
-msgstr "Déplacer vers le haut"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Move Down"
-msgstr "Déplacer vers le bas"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Remove"
-msgstr "Retirer"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Remove plugin"
-msgstr "Supprimer le module"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-#, python-brace-format
-msgid "Remove plugin '{}'?"
-msgstr "Supprimer le module '{}' ?"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Add plugin"
-msgstr "Ajouter un module"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Plugin URL (.zip):"
-msgstr "URL du module (.zip) :"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Installing plugin..."
-msgstr "Installation du module..."
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-msgid "Add plugin failed"
-msgstr "Échec de l'ajout du module"
-
-#: buzz/widgets/plugins_dialog/plugins_dialog.py
-#, python-brace-format
-msgid ""
-"Could not install the plugin:\n"
-"{}"
-msgstr ""
-"Impossible d'installer le module :\n"
-"{}"
-
-#: buzz/widgets/plugins_dialog/plugin_settings_dialog.py
-msgid "Plugin not available."
-msgstr "Module non disponible."
-
-#: buzz/widgets/transcriber/hugging_face_search_line_edit.py
-msgid "Huggingface ID of a model"
-msgstr "ID Huggingface d'un modèle"
-
-#: buzz/widgets/transcriber/file_transcription_form_widget.py
-msgid "Word-level timings"
-msgstr "Horodatages par mot"
-
-#: buzz/widgets/transcriber/file_transcription_form_widget.py
-msgid "Extract speech"
-msgstr "Extraire la parole"
-
-#: buzz/widgets/transcriber/file_transcription_form_widget.py
-msgid "Export:"
-msgstr "Exporter :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Advanced Settings"
-msgstr "Paramètres avancés"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Speech recognition settings"
-msgstr "Paramètres de reconnaissance vocale"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Initial Prompt:"
-msgstr "Invite initiale :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Translation settings"
-msgstr "Paramètres de traduction"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Enable AI translation"
-msgstr "Activer la traduction IA"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "AI model:"
-msgstr "Modèle IA :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Open documentation for AI translation models"
-msgstr "Ouvrir la documentation des modèles de traduction IA"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid ""
-"Please translate each text sent to you from English to Spanish. Translation "
-"will be used in an automated system, please do not add any comments or notes, "
-"just the translation."
-msgstr ""
-"Veuillez traduire chaque texte reçu de l'anglais vers l'espagnol. La "
-"traduction sera utilisée dans un système automatisé, ne veuillez ajouter "
-"aucun commentaire, juste la traduction."
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Instructions for AI:"
-msgstr "Instructions pour l'IA :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Recording settings"
-msgstr "Paramètres d'enregistrement"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Silence threshold:"
-msgstr "Seuil de silence :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Line separator:"
-msgstr "Séparateur de ligne :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Transcription step:"
-msgstr "Étape de transcription :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Hide unconfirmed"
-msgstr "Masquer les non confirmés"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Enable live recording export"
-msgstr "Activer l'exportation en direct"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Export folder:"
-msgstr "Dossier d'exportation :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Export file name:"
-msgstr "Nom du fichier d'exportation :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Text file (.txt)"
-msgstr "Fichier texte (.txt)"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "CSV (.csv)"
-msgstr "CSV (.csv)"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid "Export file type:"
-msgstr "Type de fichier d'exportation :"
-
-#: buzz/widgets/transcriber/advanced_settings_dialog.py
-msgid ""
-"Limit export entries\n"
-"(0 = export all):"
-msgstr ""
-"Limiter les entrées exportées\n"
-"(0 = tout exporter) :"
-
-#: buzz/widgets/transcriber/transcription_options_group_box.py
-#: buzz/transcriber/recording_transcriber.py
-msgid "First time use of a model may take up to several minutest to load."
-msgstr ""
-"La première utilisation d'un modèle peut prendre plusieurs minutes à charger."
-
-#: buzz/widgets/transcriber/transcription_options_group_box.py
-msgid "Api Key:"
-msgstr "Clé API :"
-
-#: buzz/widgets/transcriber/transcription_options_group_box.py
-msgid "Task:"
-msgstr "Tâche :"
-
-#: buzz/widgets/transcriber/transcription_options_group_box.py
-msgid "Language:"
-msgstr "Langue :"
-
-#: buzz/widgets/transcriber/mms_language_line_edit.py
-msgid "e.g., eng, fra, deu"
-msgstr "ex. : eng, fra, deu"
-
-#: buzz/widgets/transcriber/mms_language_line_edit.py
-msgid ""
-"Enter an ISO 639-3 language code (3 letters).\n"
-"Examples: eng (English), fra (French), deu (German),\n"
-"spa (Spanish), lav (Latvian)"
-msgstr ""
-"Saisissez un code de langue ISO 639-3 (3 lettres).\n"
-"Exemples : eng (Anglais), fra (Français), deu (Allemand),\n"
-"spa (Espagnol), lav (Letton)"
-
-#: buzz/widgets/transcriber/initial_prompt_text_edit.py
-msgid "Enter prompt..."
-msgstr "Saisissez l'invite..."
-
-#: buzz/widgets/transcriber/file_transcriber_widget.py
-msgid "Run"
-msgstr "Exécuter"
-
-#: buzz/widgets/transcriber/languages_combo_box.py
-#: buzz/transcriber/transcriber.py
-msgid "Detect Language"
-msgstr "Détection automatique"
-
-#: buzz/widgets/transcriber/advanced_settings_button.py
-msgid "Advanced..."
-msgstr "Avancé..."
-
-#: buzz/widgets/presentation_window.py
-msgid "Live Transcript Presentation"
-msgstr "Présentation de la transcription en direct"
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "DOCX – Speakers"
+msgstr "DOCX – Intervenants"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Save File"
+msgstr "Sauvegarder le fichier"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Text files"
+msgstr "Fichiers texte"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Include timestamps for each speaker turn?"
+msgstr "Inclure les horodatages pour chaque intervention ?"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Word documents"
+msgstr "Documents Word"
+
+#: buzz/widgets/transcription_viewer/export_transcription_menu.py
+msgid "Export Failed"
+msgstr "Échec de l'exportation"
+
+#: buzz/widgets/model_download_progress_dialog.py
+msgid "Downloading model"
+msgstr "Téléchargement du modèle"
+
+#: buzz/widgets/model_download_progress_dialog.py
+msgid "remaining"
+msgstr "restant"
 
 #: buzz/widgets/menu_bar.py
 msgid "Import File..."
@@ -1646,6 +1399,26 @@ msgstr "Modules..."
 #: buzz/widgets/menu_bar.py
 msgid "File"
 msgstr "Fichier"
+
+#: buzz/widgets/main_window.py
+msgid ""
+"Are you sure you want to delete the selected transcription(s)? This action "
+"cannot be undone."
+msgstr ""
+"Voulez-vous vraiment supprimer la/les transcription(s) sélectionnée(s) ? "
+"Cette action est irréversible."
+
+#: buzz/widgets/main_window.py
+msgid "Select audio file"
+msgstr "Sélectionner un fichier audio"
+
+#: buzz/widgets/main_window.py
+msgid "Select folder"
+msgstr "Sélectionner un dossier"
+
+#: buzz/widgets/main_window.py
+msgid "Unable to save OpenAI API key to keyring"
+msgstr "Impossible de sauvegarder la clé API OpenAI dans le trousseau"
 
 #: buzz/transcriber/local_whisper_cpp_server_transcriber.py
 #: buzz/transcriber/recording_transcriber.py
@@ -1680,10 +1453,6 @@ msgstr "Chinois"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Coréen"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Français"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2025,6 +1794,10 @@ msgstr "Soundanais"
 msgid "Cantonese"
 msgstr "Cantonais"
 
+#: buzz/transcriber/recording_transcriber.py buzz/model_loader.py
+msgid "A connection error occurred"
+msgstr "Une erreur de connexion est survenue"
+
 #: buzz/transcriber/recording_transcriber.py
 msgid "Starting Whisper.cpp..."
 msgstr "Démarrage de Whisper.cpp..."
@@ -2032,3 +1805,252 @@ msgstr "Démarrage de Whisper.cpp..."
 #: buzz/transcriber/recording_transcriber.py
 msgid "Starting transcription..."
 msgstr "Démarrage de la transcription..."
+
+#: buzz/model_loader.py
+msgid "Custom model URL is not provided"
+msgstr "L'URL du modèle personnalisé n'est pas fournie"
+
+#: buzz/settings/shortcut.py
+msgid "Open Record Window"
+msgstr "Ouvrir la fenêtre d'enregistrement"
+
+#: buzz/settings/shortcut.py
+msgid "Import File"
+msgstr "Importer un fichier"
+
+#: buzz/settings/shortcut.py
+msgid "Open Preferences Window"
+msgstr "Ouvrir les préférences"
+
+#: buzz/settings/shortcut.py
+msgid "View Transcript Text"
+msgstr "Afficher le texte de la transcription"
+
+#: buzz/settings/shortcut.py
+msgid "View Transcript Translation"
+msgstr "Afficher la traduction de la transcription"
+
+#: buzz/settings/shortcut.py
+msgid "View Transcript Timestamps"
+msgstr "Afficher les horodatages de la transcription"
+
+#: buzz/settings/shortcut.py
+msgid "Search Transcript"
+msgstr "Rechercher dans la transcription"
+
+#: buzz/settings/shortcut.py
+msgid "Go to Next Transcript Search Result"
+msgstr "Résultat suivant de la recherche"
+
+#: buzz/settings/shortcut.py
+msgid "Go to Previous Transcript Search Result"
+msgstr "Résultat précédent de la recherche"
+
+#: buzz/settings/shortcut.py
+msgid "Scroll to Current Text"
+msgstr "Faire défiler jusqu'au texte actuel"
+
+#: buzz/settings/shortcut.py
+msgid "Play/Pause Audio"
+msgstr "Lecture / Pause"
+
+#: buzz/settings/shortcut.py
+msgid "Replay Current Segment"
+msgstr "Rejouer le segment actuel"
+
+#: buzz/settings/shortcut.py
+msgid "Toggle Playback Controls"
+msgstr "Afficher / Masquer les contrôles de lecture"
+
+#: buzz/settings/shortcut.py
+msgid "Decrease Segment Start Time"
+msgstr "Diminuer le début du segment"
+
+#: buzz/settings/shortcut.py
+msgid "Increase Segment Start Time"
+msgstr "Augmenter le début du segment"
+
+#: buzz/settings/shortcut.py
+msgid "Decrease Segment End Time"
+msgstr "Diminuer la fin du segment"
+
+#: buzz/settings/shortcut.py
+msgid "Increase Segment End Time"
+msgstr "Augmenter la fin du segment"
+
+#: buzz/settings/recording_transcriber_mode.py
+msgid "Append below"
+msgstr "Ajouter en dessous"
+
+#: buzz/settings/recording_transcriber_mode.py
+msgid "Append above"
+msgstr "Ajouter au-dessus"
+
+#: buzz/settings/recording_transcriber_mode.py
+msgid "Append and correct"
+msgstr "Ajouter et corriger"
+
+#: buzz/plugins/enhanced_language_detection/plugin.py
+msgid "Enhanced language detection"
+msgstr "Détection de langue améliorée"
+
+#: buzz/plugins/enhanced_language_detection/plugin.py
+msgid ""
+"Detect the spoken language with whisper.cpp before transcription (using the "
+"largest downloaded model, or the tiny model otherwise) and use it for the "
+"transcription and exported file names. Only runs when the language is set to "
+"auto-detect."
+msgstr ""
+"Détecte la langue parlée avec whisper.cpp avant la transcription (en "
+"utilisant le plus gros modèle téléchargé, ou le modèle 'tiny' sinon) et "
+"l'utilise pour la transcription et les noms de fichiers exportés. Ne "
+"s'exécute que lorsque la langue est réglée sur 'Détection automatique'."
+
+#: buzz/plugins/enhanced_language_detection/plugin.py
+msgid "Download tiny model if none available"
+msgstr "Télécharger le modèle 'tiny' si aucun n'est disponible"
+
+#: buzz/plugins/enhanced_language_detection/plugin.py
+msgid ""
+"If no whisper.cpp model is downloaded, download the tiny model to use for "
+"language detection."
+msgstr ""
+"Si aucun modèle whisper.cpp n'est téléchargé, télécharge le modèle 'tiny' "
+"pour la détection de la langue."
+
+#: buzz/plugins/export_docx/plugin.py
+msgid "Export to DOCX"
+msgstr "Exporter en DOCX"
+
+#: buzz/plugins/export_docx/plugin.py
+msgid ""
+"Export the transcript to a Microsoft Word (.docx) file after transcription, "
+"optionally including timestamps."
+msgstr ""
+"Exporter la transcription vers un fichier Microsoft Word (.docx) après la "
+"transcription, avec la possibilité d'inclure des horodatages."
+
+#: buzz/plugins/export_docx/plugin.py buzz/plugins/ai_summary/plugin.py
+msgid "Leave empty to save next to the source file."
+msgstr "Laisser vide pour sauvegarder à côté du fichier source."
+
+#: buzz/plugins/export_docx/plugin.py
+msgid "Include timestamps"
+msgstr "Inclure les horodatages"
+
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Automatic Transcript Resizer"
+msgstr "Redimensionneur automatique de transcription"
+
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid ""
+"When a transcription has word-level timings, automatically regroup the words "
+"into properly sized subtitles and replace the result. Mirrors the Merge "
+"options of the transcript resizer."
+msgstr ""
+"Lorsqu'une transcription dispose d'horodatages au niveau des mots, regroupe "
+"automatiquement les mots en sous-titres de taille appropriée et remplace le "
+"résultat. Reflète les options de Fusion du redimensionneur de transcription."
+
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Merge gap (seconds)"
+msgstr "Espace de fusion (secondes)"
+
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Punctuation"
+msgstr "Ponctuation"
+
+#: buzz/plugins/transcript_resizer/plugin.py
+msgid "Maximum subtitle length"
+msgstr "Longueur max des sous-titres"
+
+#: buzz/plugins/deep_filter_net/plugin.py
+msgid "DeepFilterNet Noise Reduction"
+msgstr "Réduction du bruit DeepFilterNet"
+
+#: buzz/plugins/deep_filter_net/plugin.py
+msgid "Removes background noise using DeepFilterNet3 before transcription."
+msgstr ""
+"Supprime le bruit de fond en utilisant DeepFilterNet3 avant la transcription."
+
+#: buzz/plugins/deep_filter_net/plugin.py
+msgid "Keep denoised file after transcription"
+msgstr "Conserver le fichier débruité après la transcription"
+
+#: buzz/plugins/skip_already_transcribed/plugin.py
+msgid "Skip Already Transcribed"
+msgstr "Ignorer les déjà transcrits"
+
+#: buzz/plugins/skip_already_transcribed/plugin.py
+msgid "Skip transcription if results already exist on disk or in the database"
+msgstr ""
+"Ignorer la transcription si les résultats existent déjà sur le disque ou "
+"dans la base de données"
+
+#: buzz/plugins/skip_already_transcribed/plugin.py
+msgid "Check for existing result files"
+msgstr "Vérifier les fichiers de résultats existants"
+
+#: buzz/plugins/skip_already_transcribed/plugin.py
+msgid ""
+"Skip if a .txt, .srt, or .vtt file matching the audio filename is found next "
+"to it"
+msgstr ""
+"Ignorer si un fichier .txt, .srt ou .vtt correspondant au fichier audio est "
+"trouvé à côté"
+
+#: buzz/plugins/skip_already_transcribed/plugin.py
+msgid "Check in transcription database"
+msgstr "Vérifier dans la base de données des transcriptions"
+
+#: buzz/plugins/skip_already_transcribed/plugin.py
+msgid ""
+"Skip if this file has already been transcribed and the record exists in the "
+"database"
+msgstr ""
+"Ignorer si ce fichier a déjà été transcrit et que l'enregistrement existe "
+"dans la base de données"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "AI Summary"
+msgstr "Résumé IA"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid ""
+"Generate an AI summary of the transcript via an OpenAI-compatible API and "
+"save it to the Notes field and/or a file."
+msgstr ""
+"Générer un résumé IA de la transcription via une API compatible OpenAI et le "
+"sauvegarder dans le champ Notes et/ou dans un fichier."
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "API base URL"
+msgstr "URL de base de l'API"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "API key"
+msgstr "Clé API"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "Summarization prompt"
+msgstr "Invite de résumé"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "Save summary to Notes"
+msgstr "Sauvegarder le résumé dans les Notes"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "Save summary to a file"
+msgstr "Sauvegarder le résumé dans un fichier"
+
+#: buzz/plugins/ai_summary/plugin.py
+msgid "Output folder (for file)"
+msgstr "Dossier de sortie (pour le fichier)"
+
+#: buzz/file_transcriber_queue_worker.py
+msgid ""
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
+msgstr ""
+"L'extraction de la parole a échoué ! Vérifiez votre connexion internet — un "
+"modèle doit peut-être être téléchargé."

--- a/buzz/locale/it_IT/LC_MESSAGES/buzz.po
+++ b/buzz/locale/it_IT/LC_MESSAGES/buzz.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: buzz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2026-04-12 21:42+0200\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Language-Team: (Italiano) Albano Battistella <albanobattistella@gmail.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
@@ -83,6 +83,11 @@ msgstr "Danese"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Olandese"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Francese"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -231,6 +236,11 @@ msgid "Disable GPU"
 msgstr "Disabilita GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Impedisci la sospensione del sistema mentre ci sono trascrizioni in coda"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Test della chiave API OpenAI"
 
@@ -345,6 +355,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "ID Huggingface di un modello Whisper più veloce"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Nome del modello personalizzato"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Aggiungi file di modello locale"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Aggiungi modello da URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Download"
 
@@ -367,6 +389,24 @@ msgstr "Disponibile per il download"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Link per scaricare il file modello ggml Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Personalizzato"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Seleziona il file di modello Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Modello Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Tutti i file"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -722,10 +762,6 @@ msgid "Dark"
 msgstr "Scuro"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Personalizzato"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Colore del testo"
 
@@ -896,6 +932,14 @@ msgstr "Download completato!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Impossibile eseguire il programma di installazione: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Informazioni"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Versione"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1340,10 +1384,6 @@ msgid "Import Folder..."
 msgstr "Importa cartella..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Informazioni"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Preferenze..."
 
@@ -1383,8 +1423,9 @@ msgstr "Impossibile salvare la chiave API OpenAI nel portachiavi"
 #: buzz/transcriber/recording_transcriber.py
 msgid "Whisper server failed to start. Check logs for details."
 msgstr ""
-"Il server Whisper non è riuscito ad avviarsi. Controlla i log per i dettagli."
-"Impossibile avviare il server Whisper. Controllare i log per i dettagli."
+"Il server Whisper non è riuscito ad avviarsi. Controlla i log per i "
+"dettagli.Impossibile avviare il server Whisper. Controllare i log per i "
+"dettagli."
 
 #: buzz/transcriber/local_whisper_cpp_server_transcriber.py
 #: buzz/transcriber/recording_transcriber.py
@@ -1412,10 +1453,6 @@ msgstr "Cinese"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Coreano"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Francese"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2009,15 +2046,10 @@ msgstr "Salva il riepilogo in un file"
 msgid "Output folder (for file)"
 msgstr "Cartella di output (per il file)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Impedisci la sospensione del sistema mentre ci sono trascrizioni in coda"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Estrazione del parlato non riuscita! Controlla la tua connessione Internet — "
 "potrebbe essere necessario scaricare un modello."

--- a/buzz/locale/ja_JP/LC_MESSAGES/buzz.po
+++ b/buzz/locale/ja_JP/LC_MESSAGES/buzz.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: nunawa <71294849+nunawa@users.noreply.github.com>\n"
 "Language-Team: \n"
 "Language: ja_JP\n"
@@ -80,6 +80,11 @@ msgstr "デンマーク語"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "オランダ語"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "フランス語"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -223,6 +228,10 @@ msgid "Disable GPU"
 msgstr "GPUを無効にする"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr "文字起こしがキューにある間はシステムのスリープを防止する"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "OpenAI APIキー テスト"
 
@@ -337,6 +346,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Faster whisperモデルのHuggingface ID"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "カスタムモデルの名前"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "ローカルモデルファイルを追加"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "URLからモデルを追加"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -359,6 +380,24 @@ msgstr "ダウンロード可能"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Whisper.cpp ggmlモデルファイルのダウンロードリンク"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "カスタム"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Whisper.cppモデルファイルを選択"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cppモデル"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "すべてのファイル"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -711,10 +750,6 @@ msgid "Dark"
 msgstr "ダーク"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "カスタム"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "テキストの色"
 
@@ -885,6 +920,14 @@ msgstr "ダウンロード完了！"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "インストーラーの実行に失敗しました: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "About"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "バージョン"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1314,10 +1357,6 @@ msgid "Import Folder..."
 msgstr "フォルダをインポートする..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "About"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "設定..."
 
@@ -1382,10 +1421,6 @@ msgstr "中国語"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "韓国語"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "フランス語"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1975,15 +2010,10 @@ msgstr "要約をファイルに保存"
 msgid "Output folder (for file)"
 msgstr "出力フォルダ（ファイル用）"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"文字起こしがキューにある間はシステムのスリープを防止する"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "音声抽出に失敗しました！インターネット接続を確認してください。モデルのダウン"
 "ロードが必要な場合があります。"

--- a/buzz/locale/lv_LV/LC_MESSAGES/buzz.po
+++ b/buzz/locale/lv_LV/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2026-03-06 13:23+0200\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: lv_LV\n"
@@ -84,6 +84,11 @@ msgstr "Dāņu"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Holandiešu"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Franču"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -227,6 +232,10 @@ msgid "Disable GPU"
 msgstr "Deaktivēt GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr "Neļaut sistēmai iemigt, kamēr rindā ir atpazīšanas uzdevumi"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "OpenAI API atslēgas pārbaude"
 
@@ -340,6 +349,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Faster whisper modeļa Huggingface ID"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Pielāgotā modeļa nosaukums"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Pievienot lokālu modeļa failu"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Pievienot modeli no URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Lejupielādēt"
 
@@ -362,6 +383,24 @@ msgstr "Pieejams lejupielādei"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Whisper.cpp ggml modeļa datnes lejupielādes saite"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Pielāgots"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Izvēlieties Whisper.cpp modeļa failu"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cpp modelis"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Visi faili"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -714,10 +753,6 @@ msgid "Dark"
 msgstr "Tumšais"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Pielāgots"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Teksta krāsa"
 
@@ -888,6 +923,14 @@ msgstr "Lejupielāde pabeigta!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Neizdevās sākt atjauninājumu: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Par"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Versija"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1321,10 +1364,6 @@ msgid "Import Folder..."
 msgstr "Importēt mapi..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Par"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Iestatījumi..."
 
@@ -1393,10 +1432,6 @@ msgstr "Ķīniešu"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Korejiešu"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Franču"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1985,17 +2020,12 @@ msgstr "Saglabāt failā"
 msgid "Output folder (for file)"
 msgstr "Izvades mape"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Neļaut sistēmai iemigt, kamēr rindā ir atpazīšanas uzdevumi"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
-"Runas atdalīšana neizdevās! Pārbaudiet interneta savienojumu, iespējams "
+"Runas atdalīšana neizdevās! Pārbaudiet interneta savienojumu — iespējams, "
 "jālejupielādē modelis."
 
 #~ msgid "Live recording mode:"

--- a/buzz/locale/nl/LC_MESSAGES/buzz.po
+++ b/buzz/locale/nl/LC_MESSAGES/buzz.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2025-03-20 18:30+0100\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
 "Language: nl\n"
@@ -86,6 +86,11 @@ msgstr "Deens"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Nederlands"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Frans"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -231,6 +236,12 @@ msgid "Disable GPU"
 msgstr "GPU uitschakelen"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Voorkom dat het systeem in slaapstand gaat terwijl er transcripties in de "
+"wachtrij staan"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "OpenAI-api-sleuteltest"
 
@@ -345,6 +356,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Huggingface-id of een sneller Whisper-model"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Naam voor het aangepaste model"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Lokaal modelbestand toevoegen"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Model via URL toevoegen"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Downloaden"
 
@@ -367,6 +390,24 @@ msgstr "Beschikbaar"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Downloadlink van Whisper.cpp ggml-modelbestand"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Aangepast"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Whisper.cpp-modelbestand selecteren"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cpp-model"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Alle bestanden"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -684,9 +725,9 @@ msgstr ""
 #: buzz/widgets/transcription_tasks_table_widget.py
 msgid "Could not restart transcription: transcriber worker not found."
 msgstr ""
-"Kon transcriptie niet opnieuw starten: transcribeerder niet gevonden."
-"Transcriptie kon niet opnieuw worden gestart: transcriptieproces niet "
-"gevonden."
+"Kon transcriptie niet opnieuw starten: transcribeerder niet "
+"gevonden.Transcriptie kon niet opnieuw worden gestart: transcriptieproces "
+"niet gevonden."
 
 #: buzz/widgets/recording_transcriber_widget.py
 msgid "Live Recording"
@@ -723,10 +764,6 @@ msgstr "Licht"
 #: buzz/widgets/recording_transcriber_widget.py
 msgid "Dark"
 msgstr "Donker"
-
-#: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Aangepast"
 
 #: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
@@ -897,6 +934,14 @@ msgstr "Download voltooid!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Kan het installatieprogramma niet uitvoeren: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Over"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Versie"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1335,10 +1380,6 @@ msgid "Import Folder..."
 msgstr "Map importeren…"
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Over"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Instellingen…"
 
@@ -1408,10 +1449,6 @@ msgstr "Chinees"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Koreaans"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Frans"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2005,15 +2042,10 @@ msgstr "Samenvatting in een bestand opslaan"
 msgid "Output folder (for file)"
 msgstr "Uitvoermap (voor bestand)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Voorkom dat het systeem in slaapstand gaat terwijl er transcripties in de wachtrij staan"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Spraakextractie mislukt! Controleer uw internetverbinding — mogelijk moet er "
 "een model worden gedownload."

--- a/buzz/locale/pl_PL/LC_MESSAGES/buzz.po
+++ b/buzz/locale/pl_PL/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2024-03-17 20:50+0200\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pl_PL\n"
@@ -84,6 +84,11 @@ msgstr "Duński"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Niderlandzki"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Francuski"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -228,6 +233,10 @@ msgid "Disable GPU"
 msgstr "Wyłącz GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr "Zapobiegaj uśpieniu systemu, gdy w kolejce są transkrypcje"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Test klucza API OpenAI"
 
@@ -342,6 +351,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "ID modelu Faster Whisper z Huggingface"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Nazwa modelu niestandardowego"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Dodaj lokalny plik modelu"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Dodaj model z adresu URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Pobierz"
 
@@ -364,6 +385,24 @@ msgstr "Dostępne do pobrania"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Link do pobrania pliku modelu Whisper.cpp ggml"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Niestandardowy"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Wybierz plik modelu Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Model Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Wszystkie pliki"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -720,10 +759,6 @@ msgid "Dark"
 msgstr "Ciemny"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Niestandardowy"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Kolor tekstu"
 
@@ -894,6 +929,14 @@ msgstr "Pobieranie zakończone!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Nie udało się uruchomić instalatora: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "O programie"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Wersja"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1333,10 +1376,6 @@ msgid "Import Folder..."
 msgstr "Importuj folder..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "O programie"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Ustawienia..."
 
@@ -1403,10 +1442,6 @@ msgstr "Chiński"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Koreański"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Francuski"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1999,15 +2034,10 @@ msgstr "Zapisz podsumowanie w pliku"
 msgid "Output folder (for file)"
 msgstr "Folder wyjściowy (dla pliku)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Zapobiegaj uśpieniu systemu, gdy w kolejce są transkrypcje"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Wyodrębnianie mowy nie powiodło się! Sprawdź połączenie internetowe — może "
 "być konieczne pobranie modelu."

--- a/buzz/locale/pt_BR/LC_MESSAGES/buzz.po
+++ b/buzz/locale/pt_BR/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Buzz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2025-11-01 17:43-0300\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: Paulo Schopf <pschopf@gmail.com>\n"
 "Language-Team: none\n"
 "Language: pt_BR\n"
@@ -84,6 +84,11 @@ msgstr "Dinamarquês"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Holandês"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Francês"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -228,6 +233,11 @@ msgid "Disable GPU"
 msgstr "Desabilitar GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Impedir que o sistema entre em suspensão enquanto houver transcrições na fila"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Teste da Chave API OpenAI"
 
@@ -342,6 +352,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "ID Huggingface de um modelo Faster Whisper"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Nome do modelo personalizado"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Adicionar arquivo de modelo local"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Adicionar modelo a partir de URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Baixar"
 
@@ -364,6 +386,24 @@ msgstr "Disponível para Download"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Link para o arquivo de modelo Whisper.cpp ggml"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Personalizado"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Selecione o arquivo de modelo Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Modelo Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Todos os arquivos"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -720,10 +760,6 @@ msgid "Dark"
 msgstr "Escuro"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Personalizado"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Cor do Texto"
 
@@ -894,6 +930,14 @@ msgstr "Download concluído!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Falha ao executar o instalador: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Sobre"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Versão"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1331,10 +1375,6 @@ msgid "Import Folder..."
 msgstr "Importar Pasta..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Sobre"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Preferências..."
 
@@ -1401,10 +1441,6 @@ msgstr "Chinês"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Coreano"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Francês"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1997,15 +2033,10 @@ msgstr "Salvar resumo em um arquivo"
 msgid "Output folder (for file)"
 msgstr "Pasta de saída (para o arquivo)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Impedir que o sistema entre em suspensão enquanto houver transcrições na fila"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Falha na extração de fala! Verifique sua conexão com a internet — pode ser "
 "necessário baixar um modelo."

--- a/buzz/locale/ru/LC_MESSAGES/buzz.po
+++ b/buzz/locale/ru/LC_MESSAGES/buzz.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru_RU\n"
@@ -82,6 +82,11 @@ msgstr "Датский"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Нидерландский"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Французский"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -226,6 +231,11 @@ msgid "Disable GPU"
 msgstr "Отключить GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Не давать системе переходить в спящий режим, пока в очереди есть транскрипции"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Проверка API-ключа OpenAI"
 
@@ -340,6 +350,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Huggingface ID для модели Faster Whisper"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Имя пользовательской модели"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Добавить локальный файл модели"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Добавить модель по URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Скачать"
 
@@ -362,6 +384,24 @@ msgstr "Доступно для скачивания"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Ссылка для скачивания файла модели ggml Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Пользовательская"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Выберите файл модели Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Модель Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Все файлы"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -718,10 +758,6 @@ msgid "Dark"
 msgstr "Тёмная"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Пользовательская"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Цвет текста"
 
@@ -892,6 +928,14 @@ msgstr "Скачивание завершено!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Не удалось запустить установщик: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "О приложении"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Версия"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1331,10 +1375,6 @@ msgid "Import Folder..."
 msgstr "Импортировать папку..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "О приложении"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Настройки..."
 
@@ -1404,10 +1444,6 @@ msgstr "Китайский"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Корейский"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Французский"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -2000,15 +2036,10 @@ msgstr "Сохранить резюме в файл"
 msgid "Output folder (for file)"
 msgstr "Папка вывода (для файла)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Не давать системе переходить в спящий режим, пока в очереди есть транскрипции"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Не удалось извлечь речь! Проверьте подключение к интернету — возможно, нужно "
 "скачать модель."

--- a/buzz/locale/uk_UA/LC_MESSAGES/buzz.po
+++ b/buzz/locale/uk_UA/LC_MESSAGES/buzz.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: Yevhen Popok <xalt7x.service@gmail.com>\n"
 "Language-Team: \n"
 "Language: uk_UA\n"
@@ -82,6 +82,11 @@ msgstr "Датська"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "Нідерландська"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "Французька"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -226,6 +231,11 @@ msgid "Disable GPU"
 msgstr "Вимкнути GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr ""
+"Не дозволяти системі переходити в режим сну, поки в черзі є транскрипції"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "Тест API-ключа OpenAI"
 
@@ -339,6 +349,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Huggingface ID для моделі Faster Whisper"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "Назва власної моделі"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "Додати локальний файл моделі"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "Додати модель за URL"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "Завантажити"
 
@@ -361,6 +383,24 @@ msgstr "Доступно для завантаження"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Посилання на завантаження файлу ggml моделі Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "Власна"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "Виберіть файл моделі Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Модель Whisper.cpp"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "Усі файли"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -716,10 +756,6 @@ msgid "Dark"
 msgstr "Темна"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "Власна"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "Колір тексту"
 
@@ -890,6 +926,14 @@ msgstr "Завантаження завершено!"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "Не вдалося запустити інсталятор: {}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "Про застосунок"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "Версія"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1327,10 +1371,6 @@ msgid "Import Folder..."
 msgstr "Імпортувати теку..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "Про застосунок"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "Налаштування..."
 
@@ -1369,8 +1409,9 @@ msgstr "Не вдається додати до звʼязки ключів API-
 #: buzz/transcriber/recording_transcriber.py
 msgid "Whisper server failed to start. Check logs for details."
 msgstr ""
-"Сервер Whisper не зміг запуститись. Перевірте журнали для отримання деталей."
-"Не вдалося запустити сервер Whisper. Перевірте журнали для отримання деталей."
+"Сервер Whisper не зміг запуститись. Перевірте журнали для отримання "
+"деталей.Не вдалося запустити сервер Whisper. Перевірте журнали для отримання "
+"деталей."
 
 #: buzz/transcriber/local_whisper_cpp_server_transcriber.py
 #: buzz/transcriber/recording_transcriber.py
@@ -1398,10 +1439,6 @@ msgstr "Китайська"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "Корейська"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "Французька"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1994,15 +2031,10 @@ msgstr "Зберегти резюме у файл"
 msgid "Output folder (for file)"
 msgstr "Папка виводу (для файлу)"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"Не дозволяти системі переходити в режим сну, поки в черзі є транскрипції"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr ""
 "Не вдалося витягти мовлення! Перевірте підключення до інтернету — можливо, "
 "потрібно завантажити модель."

--- a/buzz/locale/zh_CN/LC_MESSAGES/buzz.po
+++ b/buzz/locale/zh_CN/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2023-05-01 15:45+0800\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: \n"
 "Language-Team: lamb\n"
 "Language: zh_CN\n"
@@ -84,6 +84,11 @@ msgstr "丹麦语"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "荷兰语"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "法语"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -223,6 +228,10 @@ msgid "Disable GPU"
 msgstr "禁用 GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr "有转录任务排队时阻止系统睡眠"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "测试OpenAI API Key"
 
@@ -332,6 +341,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "较快的Whisper模型的Huggingface ID"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "自定义模型的名称"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "添加本地模型文件"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "从 URL 添加模型"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "下载"
 
@@ -354,6 +375,24 @@ msgstr "可用的下载"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Whisper.cpp ggml 模型文件的下载链接"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "自定义"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "选择 Whisper.cpp 模型文件"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cpp 模型"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "所有文件"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -702,10 +741,6 @@ msgid "Dark"
 msgstr "深色"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "自定义"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "文字颜色"
 
@@ -872,6 +907,14 @@ msgstr "下载完成！"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "无法运行安装程序：{}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "关于"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "版本"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1295,10 +1338,6 @@ msgid "Import Folder..."
 msgstr "导入文件夹..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "关于"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "偏好设置..."
 
@@ -1362,10 +1401,6 @@ msgstr "中文"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "韩语"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "法语"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1947,15 +1982,10 @@ msgstr "将摘要保存到文件"
 msgid "Output folder (for file)"
 msgstr "输出文件夹（用于文件）"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"有转录任务排队时阻止系统睡眠"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr "语音提取失败！请检查您的网络连接——可能需要下载模型。"
 
 #~ msgid "Live recording mode:"

--- a/buzz/locale/zh_TW/LC_MESSAGES/buzz.po
+++ b/buzz/locale/zh_TW/LC_MESSAGES/buzz.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:09+0300\n"
-"PO-Revision-Date: 2023-05-01 15:45+0800\n"
+"POT-Creation-Date: 2026-09-11 18:56+0300\n"
+"PO-Revision-Date: 2026-09-11 18:58+0300\n"
 "Last-Translator: \n"
 "Language-Team: Lamb\n"
 "Language: zh_TW\n"
@@ -84,6 +84,11 @@ msgstr "丹麥語"
 #: buzz/transcriber/transcriber.py
 msgid "Dutch"
 msgstr "荷蘭語"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
+#: buzz/transcriber/transcriber.py
+msgid "French"
+msgstr "法語"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
 #: buzz/transcriber/transcriber.py
@@ -223,6 +228,10 @@ msgid "Disable GPU"
 msgstr "停用 GPU"
 
 #: buzz/widgets/preferences_dialog/general_preferences_widget.py
+msgid "Prevent system sleep while transcriptions are queued"
+msgstr "有轉錄工作排隊時防止系統睡眠"
+
+#: buzz/widgets/preferences_dialog/general_preferences_widget.py
 msgid "OpenAI API Key Test"
 msgstr "OpenAI API 金鑰測試"
 
@@ -333,6 +342,18 @@ msgid "Huggingface ID of a Faster whisper model"
 msgstr "Faster Whisper 模型的 Huggingface ID"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Name for the custom model"
+msgstr "自訂模型的名稱"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add local model file"
+msgstr "新增本機模型檔案"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Add model from URL"
+msgstr "從 URL 新增模型"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download"
 msgstr "下載"
 
@@ -355,6 +376,24 @@ msgstr "可供下載"
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Download link to Whisper.cpp ggml model file"
 msgstr "Whisper.cpp ggml 模型檔案的下載連結"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+#: buzz/widgets/transcriber/transcription_options_group_box.py
+#: buzz/widgets/recording_transcriber_widget.py
+msgid "Custom"
+msgstr "自訂"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Select Whisper.cpp model file"
+msgstr "選擇 Whisper.cpp 模型檔案"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "Whisper.cpp model"
+msgstr "Whisper.cpp 模型"
+
+#: buzz/widgets/preferences_dialog/models_preferences_widget.py
+msgid "All files"
+msgstr "所有檔案"
 
 #: buzz/widgets/preferences_dialog/models_preferences_widget.py
 msgid "Delete Model"
@@ -703,10 +742,6 @@ msgid "Dark"
 msgstr "深色"
 
 #: buzz/widgets/recording_transcriber_widget.py
-msgid "Custom"
-msgstr "自訂"
-
-#: buzz/widgets/recording_transcriber_widget.py
 msgid "Text Color"
 msgstr "文字顏色"
 
@@ -873,6 +908,14 @@ msgstr "下載完成！"
 #: buzz/widgets/update_dialog.py
 msgid "Failed to run the installer: {}"
 msgstr "無法執行安裝程式：{}"
+
+#: buzz/widgets/about_dialog.py buzz/widgets/menu_bar.py
+msgid "About"
+msgstr "關於"
+
+#: buzz/widgets/about_dialog.py
+msgid "Version"
+msgstr "版本"
 
 #: buzz/widgets/about_dialog.py
 msgid "Check for updates"
@@ -1296,10 +1339,6 @@ msgid "Import Folder..."
 msgstr "導入資料夾..."
 
 #: buzz/widgets/menu_bar.py
-msgid "About"
-msgstr "關於"
-
-#: buzz/widgets/menu_bar.py
 msgid "Preferences..."
 msgstr "偏好設定..."
 
@@ -1363,10 +1402,6 @@ msgstr "中文"
 #: buzz/transcriber/transcriber.py
 msgid "Korean"
 msgstr "韓語"
-
-#: buzz/transcriber/transcriber.py
-msgid "French"
-msgstr "法語"
 
 #: buzz/transcriber/transcriber.py
 msgid "Portuguese"
@@ -1948,15 +1983,10 @@ msgstr "將摘要儲存到檔案"
 msgid "Output folder (for file)"
 msgstr "輸出資料夾（用於檔案）"
 
-#: buzz/widgets/preferences_dialog/general_preferences_widget.py
-msgid "Prevent system sleep while transcriptions are queued"
-msgstr ""
-"有轉錄工作排隊時防止系統睡眠"
-
 #: buzz/file_transcriber_queue_worker.py
 msgid ""
-"Speech extraction failed! Check your internet connection \\u2014 a model may "
-"need to be downloaded."
+"Speech extraction failed! Check your internet connection — a model may need "
+"to be downloaded."
 msgstr "語音提取失敗！請檢查您的網路連線——可能需要下載模型。"
 
 #~ msgid "Live recording mode:"

--- a/buzz/model_loader.py
+++ b/buzz/model_loader.py
@@ -420,11 +420,16 @@ class TranscriptionModel:
         self,
         model_type: ModelType = ModelType.WHISPER,
         whisper_model_size: Optional[WhisperModelSize] = WhisperModelSize.TINY,
-        hugging_face_model_id: Optional[str] = ""
+        hugging_face_model_id: Optional[str] = "",
+        custom_model_id: Optional[str] = None,
     ):
         self.model_type = model_type
         self.whisper_model_size = whisper_model_size
         self.hugging_face_model_id = hugging_face_model_id
+        # Identifies which registered Whisper.cpp custom model this refers to when
+        # whisper_model_size is CUSTOM. None means the legacy single custom model,
+        # so objects persisted by older versions keep working unchanged.
+        self.custom_model_id = custom_model_id
 
     def __str__(self):
         match self.model_type:
@@ -508,9 +513,24 @@ class TranscriptionModel:
 
         if self.model_type == ModelType.WHISPER_CPP:
             if self.whisper_model_size == WhisperModelSize.CUSTOM:
-                # Custom models are stored as a single .bin file directly in model_root_dir
-                logging.debug("Deleting model file: %s", model_path)
-                os.remove(model_path)
+                from buzz.settings.whisper_cpp_custom_models import remove_custom_model
+
+                custom_model_id = getattr(self, "custom_model_id", None)
+                # Only delete the file if Buzz owns it (i.e. it lives inside the
+                # model root, either the legacy file or one downloaded by Buzz).
+                # A model the user registered from their own location is left in
+                # place; we just remove it from the registry.
+                buzz_owns_file = (
+                    model_path is not None
+                    and os.path.normcase(os.path.abspath(model_path)).startswith(
+                        os.path.normcase(os.path.abspath(model_root_dir))
+                    )
+                )
+                if buzz_owns_file and os.path.isfile(model_path):
+                    logging.debug("Deleting model file: %s", model_path)
+                    os.remove(model_path)
+                if custom_model_id:
+                    remove_custom_model(custom_model_id)
             else:
                 # Non-custom models are downloaded via huggingface_hub.
                 # Multiple models share the same repo directory, so we only delete
@@ -537,7 +557,10 @@ class TranscriptionModel:
 
     def get_local_model_path(self) -> Optional[str]:
         if self.model_type == ModelType.WHISPER_CPP:
-            file_path = get_whisper_cpp_file_path(size=self.whisper_model_size)
+            file_path = get_whisper_cpp_file_path(
+                size=self.whisper_model_size,
+                custom_model_id=getattr(self, "custom_model_id", None),
+            )
             if not file_path or not os.path.exists(file_path) or not os.path.isfile(file_path):
                 return None
             if self.whisper_model_size != WhisperModelSize.CUSTOM:
@@ -650,8 +673,49 @@ def get_whisper_cpp_model_names(
     return repo_id, model_name, coreml_name
 
 
-def get_whisper_cpp_file_path(size: WhisperModelSize) -> str:
+WHISPER_CPP_CUSTOM_MODELS_DIR = "custom"
+
+# Magic headers of model files that Whisper.cpp can load: legacy GGML ("ggml") and
+# the newer GGUF container ("GGUF"). Used for a cheap, offline validity check.
+WHISPER_CPP_MODEL_MAGIC_BYTES = (b"ggml", b"GGUF")
+
+
+def is_valid_whisper_cpp_model_file(path: str) -> bool:
+    """Whether ``path`` looks like a model file Whisper.cpp can load.
+
+    This is a technical check only: it verifies the file exists, is not empty and
+    starts with a known GGML/GGUF magic header. It deliberately does not judge the
+    model's language or quality, which cannot be determined from the file alone.
+    """
+    try:
+        if not path or not os.path.isfile(path):
+            return False
+        if os.path.getsize(path) < len(b"ggml"):
+            return False
+        with open(path, "rb") as model_file:
+            header = model_file.read(4)
+        return header in WHISPER_CPP_MODEL_MAGIC_BYTES
+    except OSError:
+        return False
+
+
+def get_whisper_cpp_custom_model_path(custom_model_id: str) -> str:
+    """Default download destination for a custom Whisper.cpp model file."""
+    return os.path.join(
+        model_root_dir, WHISPER_CPP_CUSTOM_MODELS_DIR, f"{custom_model_id}.bin"
+    )
+
+
+def get_whisper_cpp_file_path(
+    size: WhisperModelSize, custom_model_id: Optional[str] = None
+) -> str:
     if size == WhisperModelSize.CUSTOM:
+        if custom_model_id:
+            from buzz.settings.whisper_cpp_custom_models import get_custom_model
+
+            model = get_custom_model(model_root_dir, custom_model_id)
+            return model.path if model is not None else ""
+        # No id: the legacy single custom model at its historical fixed path.
         return os.path.join(model_root_dir, f"ggml-model-whisper-custom.bin")
 
     repo_id, model_name, _ = get_whisper_cpp_model_names(
@@ -853,7 +917,9 @@ class ModelDownloader(QRunnable):
         if self.custom_model_url:
             url = self.custom_model_url
             file_path = get_whisper_cpp_file_path(
-                size=self.model.whisper_model_size)
+                size=self.model.whisper_model_size,
+                custom_model_id=getattr(self.model, "custom_model_id", None),
+            )
             self.download_model_to_path(url=url, file_path=file_path)
             return
 

--- a/buzz/model_loader.py
+++ b/buzz/model_loader.py
@@ -675,29 +675,6 @@ def get_whisper_cpp_model_names(
 
 WHISPER_CPP_CUSTOM_MODELS_DIR = "custom"
 
-# Magic headers of model files that Whisper.cpp can load: legacy GGML ("ggml") and
-# the newer GGUF container ("GGUF"). Used for a cheap, offline validity check.
-WHISPER_CPP_MODEL_MAGIC_BYTES = (b"ggml", b"GGUF")
-
-
-def is_valid_whisper_cpp_model_file(path: str) -> bool:
-    """Whether ``path`` looks like a model file Whisper.cpp can load.
-
-    This is a technical check only: it verifies the file exists, is not empty and
-    starts with a known GGML/GGUF magic header. It deliberately does not judge the
-    model's language or quality, which cannot be determined from the file alone.
-    """
-    try:
-        if not path or not os.path.isfile(path):
-            return False
-        if os.path.getsize(path) < len(b"ggml"):
-            return False
-        with open(path, "rb") as model_file:
-            header = model_file.read(4)
-        return header in WHISPER_CPP_MODEL_MAGIC_BYTES
-    except OSError:
-        return False
-
 
 def get_whisper_cpp_custom_model_path(custom_model_id: str) -> str:
     """Default download destination for a custom Whisper.cpp model file."""

--- a/buzz/settings/whisper_cpp_custom_models.py
+++ b/buzz/settings/whisper_cpp_custom_models.py
@@ -1,0 +1,159 @@
+"""Registry for user-defined Whisper.cpp custom models.
+
+Older Buzz versions supported a single custom Whisper.cpp model stored at a fixed
+path (``ggml-model-whisper-custom.bin``). This module lets users register any
+number of custom Whisper.cpp models, each with its own name and model file, while
+keeping full backward compatibility with the legacy single-model layout.
+
+The registry is persisted as a JSON list in the existing Buzz ``QSettings`` store,
+so no new configuration file or storage mechanism is introduced.
+"""
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass, asdict
+from typing import List, Optional
+
+from PyQt6.QtCore import QSettings
+
+APP_NAME = "Buzz"
+
+# QSettings key holding the JSON-encoded list of custom Whisper.cpp models.
+_SETTINGS_KEY = "transcriber/whisper-cpp-custom-models"
+
+# The single custom model supported by older Buzz versions was stored at this
+# fixed filename inside the model root. Keeping a stable id lets us surface it in
+# the new list without moving or re-downloading it.
+LEGACY_CUSTOM_MODEL_ID = "legacy-custom"
+LEGACY_CUSTOM_MODEL_FILENAME = "ggml-model-whisper-custom.bin"
+
+
+@dataclass
+class CustomWhisperCppModel:
+    id: str
+    name: str
+    path: str
+    source_url: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict) -> "CustomWhisperCppModel":
+        return CustomWhisperCppModel(
+            id=str(data.get("id") or uuid.uuid4()),
+            name=data.get("name", ""),
+            path=data.get("path", ""),
+            source_url=data.get("source_url", ""),
+        )
+
+
+def _settings() -> QSettings:
+    return QSettings(APP_NAME, "")
+
+
+def _load_stored() -> List[CustomWhisperCppModel]:
+    raw = _settings().value(_SETTINGS_KEY, "")
+    if not raw:
+        return []
+    try:
+        entries = json.loads(raw)
+    except (ValueError, TypeError):
+        logging.warning("Could not parse custom Whisper.cpp models registry; ignoring it")
+        return []
+    models: List[CustomWhisperCppModel] = []
+    for entry in entries:
+        try:
+            models.append(CustomWhisperCppModel.from_dict(entry))
+        except Exception:
+            logging.warning("Skipping invalid custom Whisper.cpp model entry: %r", entry)
+    return models
+
+
+def _save_stored(models: List[CustomWhisperCppModel]) -> None:
+    settings = _settings()
+    settings.setValue(_SETTINGS_KEY, json.dumps([m.to_dict() for m in models]))
+    settings.sync()
+
+
+def _legacy_model(model_root_dir: str) -> Optional[CustomWhisperCppModel]:
+    """Return the pre-existing single custom model as a registry entry, if present."""
+    legacy_path = os.path.join(model_root_dir, LEGACY_CUSTOM_MODEL_FILENAME)
+    if os.path.isfile(legacy_path):
+        return CustomWhisperCppModel(
+            id=LEGACY_CUSTOM_MODEL_ID,
+            name="Custom Whisper.cpp Model",
+            path=legacy_path,
+        )
+    return None
+
+
+def get_custom_models(model_root_dir: str) -> List[CustomWhisperCppModel]:
+    """All registered custom Whisper.cpp models, including the legacy single model.
+
+    The legacy ``ggml-model-whisper-custom.bin`` file used by older Buzz versions
+    is surfaced automatically (without being copied or moved) so that upgrading
+    users keep their existing custom model. If a user has explicitly registered an
+    entry with the legacy id, that entry takes precedence.
+    """
+    models = _load_stored()
+    if not any(m.id == LEGACY_CUSTOM_MODEL_ID for m in models):
+        legacy = _legacy_model(model_root_dir)
+        if legacy is not None:
+            models = [legacy, *models]
+    return models
+
+
+def get_custom_model(
+    model_root_dir: str, model_id: str
+) -> Optional[CustomWhisperCppModel]:
+    if not model_id:
+        return None
+    for model in get_custom_models(model_root_dir):
+        if model.id == model_id:
+            return model
+    return None
+
+
+def add_custom_model(
+    name: str,
+    path: str,
+    source_url: str = "",
+    model_id: Optional[str] = None,
+) -> CustomWhisperCppModel:
+    """Register a custom model and return it.
+
+    ``path`` is stored as-is, so a model file that already exists on the user's
+    computer is referenced in place rather than copied.
+    """
+    models = _load_stored()
+    model = CustomWhisperCppModel(
+        id=model_id or str(uuid.uuid4()),
+        name=name,
+        path=path,
+        source_url=source_url,
+    )
+    # Replace an existing entry with the same id instead of duplicating it.
+    models = [m for m in models if m.id != model.id]
+    models.append(model)
+    _save_stored(models)
+    return model
+
+
+def remove_custom_model(model_id: str) -> None:
+    """Remove a model from the registry. Does not delete any file on disk."""
+    models = [m for m in _load_stored() if m.id != model_id]
+    _save_stored(models)
+
+
+def is_registered_model_file(model_root_dir: str, path: str) -> bool:
+    """Whether ``path`` is already registered by one of the custom models."""
+    if not path:
+        return False
+    normalized = os.path.normcase(os.path.abspath(path))
+    for model in get_custom_models(model_root_dir):
+        if model.path and os.path.normcase(os.path.abspath(model.path)) == normalized:
+            return True
+    return False

--- a/buzz/widgets/preferences_dialog/models_preferences_widget.py
+++ b/buzz/widgets/preferences_dialog/models_preferences_widget.py
@@ -26,7 +26,6 @@ from buzz.model_loader import (
     ModelDownloader,
     model_root_dir,
     get_whisper_cpp_custom_model_path,
-    is_valid_whisper_cpp_model_file,
 )
 from buzz.settings.settings import Settings
 from buzz.settings.whisper_cpp_custom_models import (
@@ -350,10 +349,6 @@ class ModelsPreferencesWidget(QWidget):
         if not file_path:
             return
 
-        if not is_valid_whisper_cpp_model_file(file_path):
-            self._show_invalid_model_message()
-            return
-
         add_custom_model(name=name, path=file_path)
         self.custom_model_name_input.clear()
         self.custom_model_link_input.clear()
@@ -433,23 +428,7 @@ class ModelsPreferencesWidget(QWidget):
         self.model.open_file_location()
 
     def on_download_completed(self, _: str):
-        # Validate a freshly downloaded custom model; reject it if it is not a
-        # loadable Whisper.cpp model file rather than leaving a broken entry.
         if self.pending_custom_model_id is not None:
-            model = TranscriptionModel(
-                model_type=ModelType.WHISPER_CPP,
-                whisper_model_size=WhisperModelSize.CUSTOM,
-                custom_model_id=self.pending_custom_model_id,
-            )
-            path = model.get_local_model_path()
-            if path is None or not is_valid_whisper_cpp_model_file(path):
-                model.delete_local_file()
-                self.pending_custom_model_id = None
-                self._close_progress_dialog()
-                self.add_custom_model_button.setEnabled(True)
-                self.reset()
-                self._show_invalid_model_message()
-                return
             self.custom_model_name_input.clear()
             self.custom_model_link_input.clear()
             self.pending_custom_model_id = None
@@ -494,13 +473,3 @@ class ModelsPreferencesWidget(QWidget):
         if self.progress_dialog is not None:
             self.progress_dialog.close()
             self.progress_dialog = None
-
-    def _show_invalid_model_message(self):
-        QMessageBox.warning(
-            self,
-            _("Error"),
-            _(
-                "The selected file is not a compatible Whisper.cpp model "
-                "and was not added."
-            ),
-        )

--- a/buzz/widgets/preferences_dialog/models_preferences_widget.py
+++ b/buzz/widgets/preferences_dialog/models_preferences_widget.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import uuid
 from typing import Optional
 
 from PyQt6.QtCore import Qt, QThreadPool, QLocale, QUrl
@@ -13,6 +15,7 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLayout,
     QToolButton,
+    QFileDialog,
 )
 
 from buzz.locale import _
@@ -21,8 +24,15 @@ from buzz.model_loader import (
     WhisperModelSize,
     TranscriptionModel,
     ModelDownloader,
+    model_root_dir,
+    get_whisper_cpp_custom_model_path,
+    is_valid_whisper_cpp_model_file,
 )
 from buzz.settings.settings import Settings
+from buzz.settings.whisper_cpp_custom_models import (
+    get_custom_models,
+    add_custom_model,
+)
 from buzz.widgets.model_download_progress_dialog import ModelDownloadProgressDialog
 from buzz.widgets.model_type_combo_box import ModelTypeComboBox
 from buzz.widgets.line_edit import LineEdit
@@ -44,6 +54,9 @@ class ModelsPreferencesWidget(QWidget):
         self.settings = Settings()
         self.ui_locale = self.settings.value(Settings.Key.UI_LOCALE, QLocale().name())
         self.model_downloader: Optional[ModelDownloader] = None
+        # Id of the custom model currently being downloaded from a URL, so the
+        # downloaded file can be validated once the download completes.
+        self.pending_custom_model_id: Optional[str] = None
 
         model_types = [
             model_type
@@ -105,20 +118,55 @@ class ModelsPreferencesWidget(QWidget):
         layout.addWidget(self.model_list_widget)
 
     def _setup_custom_inputs(self, layout):
+        # Faster Whisper custom model: a Hugging Face model id.
         self.custom_model_id_input = HuggingFaceSearchLineEdit()
         self.custom_model_id_input.setObjectName("ModelIdInput")
-
         self.custom_model_id_input.setPlaceholderText(_("Huggingface ID of a Faster whisper model"))
         self.custom_model_id_input.textChanged.connect(self.on_custom_model_id_input_changed)
         layout.addRow("", self.custom_model_id_input)
         self.custom_model_id_input.hide()
 
+        # Whisper.cpp custom models: name + (local file or download URL).
+        self.custom_model_name_input = LineEdit()
+        self.custom_model_name_input.setObjectName("ModelNameInput")
+        self.custom_model_name_input.setPlaceholderText(_("Name for the custom model"))
+        self.custom_model_name_input.textChanged.connect(
+            self.on_custom_model_inputs_changed
+        )
+        layout.addRow("", self.custom_model_name_input)
+        self.custom_model_name_input.hide()
+
         self.custom_model_link_input = LineEdit()
         self.custom_model_link_input.setMinimumWidth(255)
         self.custom_model_link_input.setObjectName("ModelLinkInput")
-        self.custom_model_link_input.textChanged.connect(self.on_custom_model_link_input_changed)
+        self.custom_model_link_input.textChanged.connect(
+            self.on_custom_model_inputs_changed
+        )
         layout.addRow("", self.custom_model_link_input)
         self.custom_model_link_input.hide()
+
+        custom_buttons_layout = QHBoxLayout()
+        custom_buttons_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.browse_local_model_button = QPushButton(_("Add local model file"))
+        self.browse_local_model_button.setObjectName("BrowseLocalModelButton")
+        self.browse_local_model_button.clicked.connect(
+            self.on_browse_local_model_button_clicked
+        )
+        custom_buttons_layout.addWidget(self.browse_local_model_button)
+
+        self.add_custom_model_button = QPushButton(_("Add model from URL"))
+        self.add_custom_model_button.setObjectName("AddCustomModelButton")
+        self.add_custom_model_button.clicked.connect(
+            self.on_add_custom_model_button_clicked
+        )
+        custom_buttons_layout.addWidget(self.add_custom_model_button)
+        custom_buttons_layout.addStretch(1)
+
+        self.custom_buttons_widget = QWidget()
+        self.custom_buttons_widget.setLayout(custom_buttons_layout)
+        layout.addRow("", self.custom_buttons_widget)
+        self.custom_buttons_widget.hide()
 
     def _setup_action_buttons(self, layout):
         buttons_layout = QHBoxLayout()
@@ -149,14 +197,21 @@ class ModelsPreferencesWidget(QWidget):
         item_data = current.data(0, Qt.ItemDataRole.UserRole)
         if item_data is None:
             return
-        self.model.whisper_model_size = item_data
+        # Item data is a (WhisperModelSize, custom_model_id) tuple.
+        model_size, custom_model_id = item_data
+        self.model.whisper_model_size = model_size
+        self.model.custom_model_id = custom_model_id
         self.reset()
+
+    def _is_whisper_cpp(self) -> bool:
+        return self.model is not None and self.model.model_type == ModelType.WHISPER_CPP
 
     def reset(self):
         # reset buttons
         path = self.model.get_local_model_path()
-        self.download_button.setVisible(path is None)
-        self.download_button.setEnabled(self.model.whisper_model_size != WhisperModelSize.CUSTOM)
+        is_custom = self.model.whisper_model_size == WhisperModelSize.CUSTOM
+        self.download_button.setVisible(path is None and not is_custom)
+        self.download_button.setEnabled(not is_custom)
         self.delete_button.setVisible(self.model.is_deletable())
         self.show_file_location_button.setVisible(self.model.is_deletable())
 
@@ -178,36 +233,47 @@ class ModelsPreferencesWidget(QWidget):
         self.model.hugging_face_model_id = self.settings.load_custom_model_id(self.model)
         self.custom_model_id_input.setText(self.model.hugging_face_model_id)
 
+        # Faster Whisper custom model input (Hugging Face id)
         if (self.model.whisper_model_size == WhisperModelSize.CUSTOM
                 and self.model.model_type == ModelType.FASTER_WHISPER):
             self.custom_model_id_input.show()
+            self.download_button.setVisible(True)
             self.download_button.setEnabled(
                 self.model.hugging_face_model_id != ""
             )
         else:
             self.custom_model_id_input.hide()
 
-        if self.model.model_type == ModelType.WHISPER_CPP:
+        # Whisper.cpp custom model inputs (name + local file / URL)
+        if self._is_whisper_cpp():
             self.custom_model_link_input.setPlaceholderText(
                 _("Download link to Whisper.cpp ggml model file")
             )
-
-        if (self.model.whisper_model_size == WhisperModelSize.CUSTOM
-                and self.model.model_type == ModelType.WHISPER_CPP
-                and path is None):
+            self.custom_model_name_input.show()
             self.custom_model_link_input.show()
-            self.download_button.setEnabled(
-                self.custom_model_link_input.text() != "")
+            self.custom_buttons_widget.show()
+            self.on_custom_model_inputs_changed()
         else:
+            self.custom_model_name_input.hide()
             self.custom_model_link_input.hide()
+            self.custom_buttons_widget.hide()
 
         if self.model is None:
             return
 
+        self._populate_model_list(downloaded_item, available_item)
+
+    def _populate_model_list(self, downloaded_item, available_item):
         for model_size in WhisperModelSize:
             # Skip custom size for OpenAI Whisper
             if (self.model.model_type == ModelType.WHISPER and
                     model_size == WhisperModelSize.CUSTOM):
+                continue
+
+            # Whisper.cpp custom models are listed individually below, not as a
+            # single generic "Custom" entry.
+            if (model_size == WhisperModelSize.CUSTOM
+                    and self.model.model_type == ModelType.WHISPER_CPP):
                 continue
 
             # Skip LUMII size for all non Latvians
@@ -224,13 +290,37 @@ class ModelsPreferencesWidget(QWidget):
             parent = downloaded_item if model_path is not None else available_item
             item = QTreeWidgetItem(parent)
             item.setText(0, model_size.value.title())
-            item.setData(0, Qt.ItemDataRole.UserRole, model_size)
-            if self.model.whisper_model_size == model_size:
+            item.setData(0, Qt.ItemDataRole.UserRole, (model_size, None))
+            if (self.model.whisper_model_size == model_size
+                    and self.model.custom_model_id is None):
                 item.setSelected(True)
             parent.addChild(item)
 
+        # List each registered Whisper.cpp custom model by name.
+        if self.model.model_type == ModelType.WHISPER_CPP:
+            for custom_model in get_custom_models(model_root_dir):
+                model = TranscriptionModel(
+                    model_type=ModelType.WHISPER_CPP,
+                    whisper_model_size=WhisperModelSize.CUSTOM,
+                    custom_model_id=custom_model.id,
+                )
+                model_path = model.get_local_model_path()
+                parent = downloaded_item if model_path is not None else available_item
+                item = QTreeWidgetItem(parent)
+                item.setText(0, custom_model.name or _("Custom"))
+                item.setData(
+                    0,
+                    Qt.ItemDataRole.UserRole,
+                    (WhisperModelSize.CUSTOM, custom_model.id),
+                )
+                if (self.model.whisper_model_size == WhisperModelSize.CUSTOM
+                        and self.model.custom_model_id == custom_model.id):
+                    item.setSelected(True)
+                parent.addChild(item)
+
     def on_model_type_changed(self, model_type: ModelType):
         self.model.model_type = model_type
+        self.model.custom_model_id = None
         self.reset()
 
     def on_custom_model_id_input_changed(self, text):
@@ -240,8 +330,68 @@ class ModelsPreferencesWidget(QWidget):
             self.model.hugging_face_model_id != ""
         )
 
-    def on_custom_model_link_input_changed(self, text):
-        self.download_button.setEnabled(text != "")
+    def on_custom_model_inputs_changed(self, *_args):
+        has_name = self.custom_model_name_input.text().strip() != ""
+        has_url = self.custom_model_link_input.text().strip() != ""
+        self.add_custom_model_button.setEnabled(has_name and has_url)
+        self.browse_local_model_button.setEnabled(has_name)
+
+    def on_browse_local_model_button_clicked(self):
+        name = self.custom_model_name_input.text().strip()
+        if not name:
+            return
+
+        file_path, _filter = QFileDialog.getOpenFileName(
+            self,
+            _("Select Whisper.cpp model file"),
+            "",
+            _("Whisper.cpp model") + " (*.bin *.gguf);;" + _("All files") + " (*)",
+        )
+        if not file_path:
+            return
+
+        if not is_valid_whisper_cpp_model_file(file_path):
+            self._show_invalid_model_message()
+            return
+
+        add_custom_model(name=name, path=file_path)
+        self.custom_model_name_input.clear()
+        self.custom_model_link_input.clear()
+        self.reset()
+
+    def on_add_custom_model_button_clicked(self):
+        name = self.custom_model_name_input.text().strip()
+        url = self.custom_model_link_input.text().strip()
+        if not name or not url:
+            return
+
+        model_id = str(uuid.uuid4())
+        destination = get_whisper_cpp_custom_model_path(model_id)
+        add_custom_model(name=name, path=destination, source_url=url, model_id=model_id)
+
+        self.pending_custom_model_id = model_id
+        download_model = TranscriptionModel(
+            model_type=ModelType.WHISPER_CPP,
+            whisper_model_size=WhisperModelSize.CUSTOM,
+            custom_model_id=model_id,
+        )
+
+        self.progress_dialog = ModelDownloadProgressDialog(
+            model_type=ModelType.WHISPER_CPP,
+            modality=self.progress_dialog_modality,
+            parent=self,
+        )
+        self.progress_dialog.canceled.connect(self.on_progress_dialog_canceled)
+
+        self.add_custom_model_button.setEnabled(False)
+        self.model_downloader = ModelDownloader(
+            model=download_model,
+            custom_model_url=url,
+        )
+        self.model_downloader.signals.finished.connect(self.on_download_completed)
+        self.model_downloader.signals.progress.connect(self.on_download_progress)
+        self.model_downloader.signals.error.connect(self.on_download_error)
+        QThreadPool().globalInstance().start(self.model_downloader)
 
     def on_download_button_clicked(self):
         self.progress_dialog = ModelDownloadProgressDialog(
@@ -253,15 +403,7 @@ class ModelsPreferencesWidget(QWidget):
 
         self.download_button.setEnabled(False)
 
-        if (self.model.whisper_model_size == WhisperModelSize.CUSTOM and
-                self.model.model_type == ModelType.WHISPER_CPP):
-            self.model_downloader = ModelDownloader(
-                model=self.model,
-                custom_model_url=self.custom_model_link_input.text()
-            )
-        else:
-            self.model_downloader = ModelDownloader(model=self.model)
-
+        self.model_downloader = ModelDownloader(model=self.model)
         self.model_downloader.signals.finished.connect(self.on_download_completed)
         self.model_downloader.signals.progress.connect(self.on_download_progress)
         self.model_downloader.signals.error.connect(self.on_download_error)
@@ -282,30 +424,83 @@ class ModelsPreferencesWidget(QWidget):
 
         if user_choice == QMessageBox.StandardButton.Yes:
             self.model.delete_local_file()
+            # If the deleted model was a custom one, fall back to a safe selection.
+            if self.model.whisper_model_size == WhisperModelSize.CUSTOM:
+                self.model.custom_model_id = None
             self.reset()
 
     def on_show_file_location_button_clicked(self):
         self.model.open_file_location()
 
     def on_download_completed(self, _: str):
-        self.progress_dialog.close()
-        self.progress_dialog = None
+        # Validate a freshly downloaded custom model; reject it if it is not a
+        # loadable Whisper.cpp model file rather than leaving a broken entry.
+        if self.pending_custom_model_id is not None:
+            model = TranscriptionModel(
+                model_type=ModelType.WHISPER_CPP,
+                whisper_model_size=WhisperModelSize.CUSTOM,
+                custom_model_id=self.pending_custom_model_id,
+            )
+            path = model.get_local_model_path()
+            if path is None or not is_valid_whisper_cpp_model_file(path):
+                model.delete_local_file()
+                self.pending_custom_model_id = None
+                self._close_progress_dialog()
+                self.add_custom_model_button.setEnabled(True)
+                self.reset()
+                self._show_invalid_model_message()
+                return
+            self.custom_model_name_input.clear()
+            self.custom_model_link_input.clear()
+            self.pending_custom_model_id = None
+
+        self._close_progress_dialog()
         self.download_button.setEnabled(True)
+        self.add_custom_model_button.setEnabled(True)
         self.reset()
 
     def on_download_error(self, error: str):
-        self.progress_dialog.cancel()
-        self.progress_dialog.close()
-        self.progress_dialog = None
+        if self.pending_custom_model_id is not None:
+            # Remove the half-registered custom model on failure.
+            from buzz.settings.whisper_cpp_custom_models import remove_custom_model
+
+            remove_custom_model(self.pending_custom_model_id)
+            self.pending_custom_model_id = None
+        if self.progress_dialog is not None:
+            self.progress_dialog.cancel()
+        self._close_progress_dialog()
         self.download_button.setEnabled(True)
+        self.add_custom_model_button.setEnabled(True)
         self.reset()
         download_failed_label = _('Download failed')
         QMessageBox.warning(self, _("Error"), f"{download_failed_label}: {error}")
 
     def on_download_progress(self, progress: tuple):
-        if progress[1] != 0:
+        if self.progress_dialog is not None and progress[1] != 0:
             self.progress_dialog.set_value(float(progress[0]) / progress[1])
 
     def on_progress_dialog_canceled(self):
-        self.model_downloader.cancel()
+        if self.model_downloader is not None:
+            self.model_downloader.cancel()
+        if self.pending_custom_model_id is not None:
+            from buzz.settings.whisper_cpp_custom_models import remove_custom_model
+
+            remove_custom_model(self.pending_custom_model_id)
+            self.pending_custom_model_id = None
+        self.add_custom_model_button.setEnabled(True)
         self.reset()
+
+    def _close_progress_dialog(self):
+        if self.progress_dialog is not None:
+            self.progress_dialog.close()
+            self.progress_dialog = None
+
+    def _show_invalid_model_message(self):
+        QMessageBox.warning(
+            self,
+            _("Error"),
+            _(
+                "The selected file is not a compatible Whisper.cpp model "
+                "and was not added."
+            ),
+        )

--- a/buzz/widgets/transcriber/transcription_options_group_box.py
+++ b/buzz/widgets/transcriber/transcription_options_group_box.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import platform
 from typing import Optional, List
@@ -10,7 +9,8 @@ from PyQt6.QtWidgets import QGroupBox, QWidget, QFormLayout, QComboBox, QLabel, 
 from buzz.locale import _
 from buzz.settings.settings import Settings
 from buzz.widgets.icon import INFO_ICON_PATH
-from buzz.model_loader import ModelType, WhisperModelSize, get_whisper_cpp_file_path, is_mms_model
+from buzz.model_loader import ModelType, WhisperModelSize, model_root_dir, is_mms_model
+from buzz.settings.whisper_cpp_custom_models import get_custom_models
 from buzz.transcriber.transcriber import TranscriptionOptions, Task
 from buzz.widgets.model_type_combo_box import ModelTypeComboBox
 from buzz.widgets.openai_api_key_line_edit import OpenAIAPIKeyLineEdit
@@ -59,10 +59,10 @@ class TranscriptionOptionsGroupBox(QGroupBox):
         )
 
         self.whisper_model_size_combo_box = QComboBox(self)
-        self.whisper_model_size_combo_box.addItems(
-            [size.value.title() for size in WhisperModelSize if size not in {WhisperModelSize.CUSTOM, WhisperModelSize.LUMII}]
-        )
-        self.whisper_model_size_combo_box.currentTextChanged.connect(
+        # Items are populated in reset_visible_rows so that Whisper.cpp custom
+        # models can be listed by name. Each item stores a
+        # (WhisperModelSize, custom_model_id) tuple as its data.
+        self.whisper_model_size_combo_box.currentIndexChanged.connect(
             self.on_whisper_model_size_changed
         )
 
@@ -185,45 +185,7 @@ class TranscriptionOptionsGroupBox(QGroupBox):
                 and whisper_model_size == WhisperModelSize.CUSTOM),
             )
 
-        # Remove custom model size for whisper
-        custom_model_index = (self.whisper_model_size_combo_box
-                              .findText(WhisperModelSize.CUSTOM.value.title()))
-        if model_type == ModelType.WHISPER and custom_model_index != -1:
-            self.whisper_model_size_combo_box.removeItem(custom_model_index)
-
-        # Add custom model size for whisper_cpp
-        custom_model_index = (self.whisper_model_size_combo_box
-                              .findText(WhisperModelSize.CUSTOM.value.title()))
-        if (model_type == ModelType.WHISPER_CPP
-                and os.path.isfile(get_whisper_cpp_file_path(size=WhisperModelSize.CUSTOM))
-                and custom_model_index == -1):
-            self.whisper_model_size_combo_box.addItem(
-                WhisperModelSize.CUSTOM.value.title()
-            )
-
-        # Add custom model size for faster_whisper
-        custom_model_index = (self.whisper_model_size_combo_box
-                              .findText(WhisperModelSize.CUSTOM.value.title()))
-        if model_type == ModelType.FASTER_WHISPER and custom_model_index == -1:
-            self.whisper_model_size_combo_box.addItem(
-                WhisperModelSize.CUSTOM.value.title()
-            )
-
-        # Leave LUMII model only for Latvian whisper_cpp
-        lumii_model_index = (self.whisper_model_size_combo_box
-                              .findText(WhisperModelSize.LUMII.value.title()))
-
-        if lumii_model_index != -1 and (model_type != ModelType.WHISPER_CPP or self.ui_locale != "lv_LV"):
-            self.whisper_model_size_combo_box.removeItem(lumii_model_index)
-
-        if lumii_model_index == -1 and model_type == ModelType.WHISPER_CPP and self.ui_locale == "lv_LV":
-            self.whisper_model_size_combo_box.addItem(
-                WhisperModelSize.LUMII.value.title()
-            )
-
-        self.whisper_model_size_combo_box.setCurrentText(
-            self.transcription_options.model.whisper_model_size.value.title()
-        )
+        self._populate_whisper_model_size_combo_box()
 
         self.form_layout.setRowVisible(
             self.whisper_model_size_combo_box,
@@ -264,9 +226,67 @@ class TranscriptionOptionsGroupBox(QGroupBox):
         self.reset_visible_rows()
         self.transcription_options_changed.emit(self.transcription_options)
 
-    def on_whisper_model_size_changed(self, text: str):
-        model_size = WhisperModelSize(text.lower())
+    def _populate_whisper_model_size_combo_box(self):
+        """Rebuild the model-size items, listing Whisper.cpp custom models by name.
+
+        Each item stores a (WhisperModelSize, custom_model_id) tuple. Regular
+        sizes use a None id; Whisper.cpp custom models carry their registry id so
+        several of them can coexist and be selected independently.
+        """
+        model_type = self.transcription_options.model.model_type
+        combo = self.whisper_model_size_combo_box
+
+        combo.blockSignals(True)
+        combo.clear()
+
+        for size in WhisperModelSize:
+            if size in {WhisperModelSize.CUSTOM, WhisperModelSize.LUMII}:
+                continue
+            combo.addItem(size.value.title(), (size, None))
+
+        # LUMII (Latvian) is only offered for Whisper.cpp in the Latvian locale.
+        if model_type == ModelType.WHISPER_CPP and self.ui_locale == "lv_LV":
+            combo.addItem(
+                WhisperModelSize.LUMII.value.title(), (WhisperModelSize.LUMII, None)
+            )
+
+        if model_type == ModelType.FASTER_WHISPER:
+            combo.addItem(
+                WhisperModelSize.CUSTOM.value.title(), (WhisperModelSize.CUSTOM, None)
+            )
+        elif model_type == ModelType.WHISPER_CPP:
+            for model in get_custom_models(model_root_dir):
+                combo.addItem(
+                    model.name or _("Custom"), (WhisperModelSize.CUSTOM, model.id)
+                )
+
+        self._select_current_whisper_model_size()
+        combo.blockSignals(False)
+
+    def _select_current_whisper_model_size(self):
+        combo = self.whisper_model_size_combo_box
+        model = self.transcription_options.model
+        target = (model.whisper_model_size, getattr(model, "custom_model_id", None))
+
+        for index in range(combo.count()):
+            if combo.itemData(index) == target:
+                combo.setCurrentIndex(index)
+                return
+        # Fall back to matching by size alone (e.g. a custom id that no longer
+        # exists), so the selection stays valid.
+        for index in range(combo.count()):
+            data = combo.itemData(index)
+            if data is not None and data[0] == model.whisper_model_size:
+                combo.setCurrentIndex(index)
+                return
+
+    def on_whisper_model_size_changed(self, _index: int):
+        data = self.whisper_model_size_combo_box.currentData()
+        if data is None:
+            return
+        model_size, custom_model_id = data
         self.transcription_options.model.whisper_model_size = model_size
+        self.transcription_options.model.custom_model_id = custom_model_id
 
         self.reset_visible_rows()
 

--- a/docs/docs/custom_whisper_cpp_models.md
+++ b/docs/docs/custom_whisper_cpp_models.md
@@ -22,10 +22,6 @@ without re-downloading anything.
      example the download link from a Hugging Face model page). Buzz downloads it and
      adds it.
 
-The model is checked to make sure it is a Whisper.cpp model file that this version of
-Buzz can load. This is a technical check only — it does not judge the model's language
-or quality. A file that is not a compatible Whisper.cpp model is rejected and not added.
-
 ## Selecting a model
 
 Each custom model appears by its name in the model list in **Preferences → Models** and

--- a/docs/docs/custom_whisper_cpp_models.md
+++ b/docs/docs/custom_whisper_cpp_models.md
@@ -1,0 +1,54 @@
+---
+title: Custom Whisper.cpp models
+---
+
+# Custom Whisper.cpp models
+
+Buzz can use any number of custom [Whisper.cpp](https://github.com/ggerganov/whisper.cpp)
+models in addition to the built-in ones. This is useful when you have several
+fine-tuned models — for example a fast model you use by default and a more accurate
+model you fall back to for difficult recordings — and want to switch between them
+without re-downloading anything.
+
+## Adding a custom model
+
+1. Open **Preferences → Models**.
+2. Set the model **Group** to **Whisper.cpp**.
+3. Enter a **name** for the model.
+4. Add the model file in one of two ways:
+   - **Add local model file** — choose a `ggml`/`gguf` `.bin` file that is already on
+     your computer. The file is used from its current location; it is not copied.
+   - **Add model from URL** — paste a download link to the model `.bin` file (for
+     example the download link from a Hugging Face model page). Buzz downloads it and
+     adds it.
+
+The model is checked to make sure it is a Whisper.cpp model file that this version of
+Buzz can load. This is a technical check only — it does not judge the model's language
+or quality. A file that is not a compatible Whisper.cpp model is rejected and not added.
+
+## Selecting a model
+
+Each custom model appears by its name in the model list in **Preferences → Models** and
+in the model selector on the main transcription screen. Select the one you want to use;
+switch to another at any time.
+
+## Deleting a model
+
+Deleting a custom model removes it from the list. If Buzz downloaded the model file, that
+file is also deleted. If you added a model that was already on your computer, only the
+list entry is removed — your original file is left untouched.
+
+## Upgrading from earlier versions
+
+Earlier versions of Buzz supported a single custom Whisper.cpp model stored as
+`ggml-model-whisper-custom.bin`. If you have such a model, it continues to work: it
+appears automatically in the list as **Custom Whisper.cpp Model** and is neither moved
+nor re-downloaded.
+
+## Command line
+
+A custom model can be selected non-interactively with its id:
+
+```
+buzz add --model-type whispercpp --model-size custom --custom-model-id <id> <file>
+```

--- a/docs/docs/preferences.md
+++ b/docs/docs/preferences.md
@@ -58,8 +58,11 @@ processing power and more powerful hardware to work.
 
 This section lets you download new models for transcription and delete unused ones.
 
-For Whisper.cpp you can also download custom models. Select `Custom` in the model size list and paste the download url 
-to the model `.bin` file. Use the link from "download" button from the Huggingface. 
+For Whisper.cpp you can also add any number of custom models. Enter a name and then either
+add a model file that is already on your computer or download one from a URL to its `.bin`
+file (use the link from the "download" button on Huggingface). Each custom model appears by
+name in the model list so you can switch between them. See
+[Custom Whisper.cpp models](./custom_whisper_cpp_models.md) for details.
 
 To improve transcription speed and memory usage you can select a quantized version of some 
 larger model. For example `q_5` version. Whisper.cpp base models in different quantizations are [available here](https://huggingface.co/ggerganov/whisper.cpp/tree/main). See also [custom models](https://github.com/chidiwilliams/buzz/discussions/866) discussion page for custom models in different languages.

--- a/tests/model_loader_test.py
+++ b/tests/model_loader_test.py
@@ -543,13 +543,34 @@ class TestTranscriptionModelDeleteLocalFile:
             model.delete_local_file()
         assert not model_file.exists()
 
-    def test_whisper_cpp_custom_removes_file(self, tmp_path):
+    def test_whisper_cpp_custom_removes_file_owned_by_buzz(self, tmp_path):
         model_file = tmp_path / "ggml-model-whisper-custom.bin"
         model_file.write_bytes(b"fake model data")
         model = TranscriptionModel(model_type=ModelType.WHISPER_CPP, whisper_model_size=WhisperModelSize.CUSTOM)
-        with patch.object(model, 'get_local_model_path', return_value=str(model_file)):
+        with patch("buzz.model_loader.model_root_dir", str(tmp_path)), \
+             patch.object(model, 'get_local_model_path', return_value=str(model_file)):
             model.delete_local_file()
         assert not model_file.exists()
+
+    def test_whisper_cpp_custom_keeps_file_outside_model_root(self, tmp_path):
+        model_root = tmp_path / "models"
+        model_root.mkdir()
+        user_dir = tmp_path / "elsewhere"
+        user_dir.mkdir()
+        model_file = user_dir / "my-own-model.bin"
+        model_file.write_bytes(b"fake model data")
+        model = TranscriptionModel(
+            model_type=ModelType.WHISPER_CPP,
+            whisper_model_size=WhisperModelSize.CUSTOM,
+            custom_model_id="my-own-model",
+        )
+        with patch("buzz.model_loader.model_root_dir", str(model_root)), \
+             patch("buzz.settings.whisper_cpp_custom_models.remove_custom_model") as mock_remove, \
+             patch.object(model, 'get_local_model_path', return_value=str(model_file)):
+            model.delete_local_file()
+        # The user's own file is left in place, only the registry entry is removed
+        assert model_file.exists()
+        mock_remove.assert_called_once_with("my-own-model")
 
     def test_whisper_cpp_non_custom_removes_bin_file(self, tmp_path):
         model_file = tmp_path / "ggml-tiny.bin"

--- a/tests/settings/whisper_cpp_custom_models_test.py
+++ b/tests/settings/whisper_cpp_custom_models_test.py
@@ -1,0 +1,139 @@
+import os
+
+import pytest
+from PyQt6.QtCore import QSettings
+
+from buzz.model_loader import (
+    ModelType,
+    TranscriptionModel,
+    WhisperModelSize,
+    get_whisper_cpp_file_path,
+    is_valid_whisper_cpp_model_file,
+)
+from buzz.settings import whisper_cpp_custom_models as registry
+from buzz.settings.whisper_cpp_custom_models import (
+    LEGACY_CUSTOM_MODEL_FILENAME,
+    LEGACY_CUSTOM_MODEL_ID,
+    add_custom_model,
+    get_custom_model,
+    get_custom_models,
+    is_registered_model_file,
+    remove_custom_model,
+)
+
+
+def _write_model_file(path: str, magic: bytes = b"ggml") -> str:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as model_file:
+        model_file.write(magic + b"\x00" * 128)
+    return path
+
+
+@pytest.fixture()
+def isolated_registry(tmp_path, monkeypatch):
+    """Back the registry with a throwaway ini file so tests don't touch real settings."""
+    ini_path = str(tmp_path / "settings.ini")
+
+    def _settings():
+        return QSettings(ini_path, QSettings.Format.IniFormat)
+
+    monkeypatch.setattr(registry, "_settings", _settings)
+    return tmp_path
+
+
+class TestValidation:
+    def test_accepts_ggml_and_gguf_headers(self, tmp_path):
+        ggml = _write_model_file(str(tmp_path / "ggml.bin"), b"ggml")
+        gguf = _write_model_file(str(tmp_path / "gguf.bin"), b"GGUF")
+        assert is_valid_whisper_cpp_model_file(ggml)
+        assert is_valid_whisper_cpp_model_file(gguf)
+
+    def test_rejects_wrong_magic_and_missing_file(self, tmp_path):
+        bad = _write_model_file(str(tmp_path / "bad.bin"), b"nope")
+        assert not is_valid_whisper_cpp_model_file(bad)
+        assert not is_valid_whisper_cpp_model_file(str(tmp_path / "missing.bin"))
+        assert not is_valid_whisper_cpp_model_file("")
+
+
+class TestRegistry:
+    def test_add_and_get_multiple_models(self, isolated_registry):
+        turbo = add_custom_model(name="Hebrew Turbo", path=r"C:\models\turbo.bin")
+        v3 = add_custom_model(name="Hebrew v3", path=r"C:\models\v3.bin")
+
+        assert turbo.id != v3.id
+        models = get_custom_models(str(isolated_registry))
+        assert [m.name for m in models] == ["Hebrew Turbo", "Hebrew v3"]
+        assert get_custom_model(str(isolated_registry), turbo.id).path == r"C:\models\turbo.bin"
+        assert get_custom_model(str(isolated_registry), v3.id).path == r"C:\models\v3.bin"
+
+    def test_supports_many_models_without_arbitrary_limit(self, isolated_registry):
+        for index in range(20):
+            add_custom_model(name=f"Model {index}", path=rf"C:\models\{index}.bin")
+        assert len(get_custom_models(str(isolated_registry))) == 20
+
+    def test_models_persist_across_reload(self, isolated_registry):
+        model = add_custom_model(name="Persisted", path=r"C:\models\persisted.bin")
+        # Reading through a fresh call re-reads from the backing store.
+        reloaded = get_custom_model(str(isolated_registry), model.id)
+        assert reloaded is not None
+        assert reloaded.name == "Persisted"
+
+    def test_remove_only_targets_one_model(self, isolated_registry):
+        turbo = add_custom_model(name="Hebrew Turbo", path=r"C:\models\turbo.bin")
+        v3 = add_custom_model(name="Hebrew v3", path=r"C:\models\v3.bin")
+
+        remove_custom_model(turbo.id)
+
+        remaining = get_custom_models(str(isolated_registry))
+        assert [m.id for m in remaining] == [v3.id]
+
+    def test_is_registered_model_file(self, isolated_registry):
+        add_custom_model(name="Local", path=str(isolated_registry / "local.bin"))
+        assert is_registered_model_file(str(isolated_registry), str(isolated_registry / "local.bin"))
+        assert not is_registered_model_file(str(isolated_registry), str(isolated_registry / "other.bin"))
+
+
+class TestLegacyCompatibility:
+    def test_legacy_model_file_is_surfaced(self, isolated_registry):
+        legacy_path = _write_model_file(
+            os.path.join(str(isolated_registry), LEGACY_CUSTOM_MODEL_FILENAME)
+        )
+        models = get_custom_models(str(isolated_registry))
+        assert len(models) == 1
+        assert models[0].id == LEGACY_CUSTOM_MODEL_ID
+        assert models[0].path == legacy_path
+
+    def test_no_legacy_entry_when_file_absent(self, isolated_registry):
+        assert get_custom_models(str(isolated_registry)) == []
+
+
+class TestPathResolution:
+    def test_custom_id_resolves_to_registered_path(self, isolated_registry):
+        model = add_custom_model(name="Hebrew Turbo", path=r"C:\models\turbo.bin")
+        assert (
+            get_whisper_cpp_file_path(WhisperModelSize.CUSTOM, custom_model_id=model.id)
+            == r"C:\models\turbo.bin"
+        )
+
+    def test_missing_custom_id_resolves_empty(self, isolated_registry):
+        assert (
+            get_whisper_cpp_file_path(WhisperModelSize.CUSTOM, custom_model_id="does-not-exist")
+            == ""
+        )
+
+    def test_no_custom_id_uses_legacy_fixed_path(self, isolated_registry):
+        legacy = get_whisper_cpp_file_path(WhisperModelSize.CUSTOM)
+        assert legacy.endswith(LEGACY_CUSTOM_MODEL_FILENAME)
+
+    def test_object_without_custom_model_id_attr_still_resolves(self, isolated_registry):
+        # Simulates a TranscriptionModel unpickled from an older Buzz version.
+        model = TranscriptionModel(
+            model_type=ModelType.WHISPER_CPP,
+            whisper_model_size=WhisperModelSize.CUSTOM,
+        )
+        del model.custom_model_id
+        resolved = get_whisper_cpp_file_path(
+            model.whisper_model_size,
+            custom_model_id=getattr(model, "custom_model_id", None),
+        )
+        assert resolved.endswith(LEGACY_CUSTOM_MODEL_FILENAME)

--- a/tests/settings/whisper_cpp_custom_models_test.py
+++ b/tests/settings/whisper_cpp_custom_models_test.py
@@ -8,7 +8,6 @@ from buzz.model_loader import (
     TranscriptionModel,
     WhisperModelSize,
     get_whisper_cpp_file_path,
-    is_valid_whisper_cpp_model_file,
 )
 from buzz.settings import whisper_cpp_custom_models as registry
 from buzz.settings.whisper_cpp_custom_models import (
@@ -39,20 +38,6 @@ def isolated_registry(tmp_path, monkeypatch):
 
     monkeypatch.setattr(registry, "_settings", _settings)
     return tmp_path
-
-
-class TestValidation:
-    def test_accepts_ggml_and_gguf_headers(self, tmp_path):
-        ggml = _write_model_file(str(tmp_path / "ggml.bin"), b"ggml")
-        gguf = _write_model_file(str(tmp_path / "gguf.bin"), b"GGUF")
-        assert is_valid_whisper_cpp_model_file(ggml)
-        assert is_valid_whisper_cpp_model_file(gguf)
-
-    def test_rejects_wrong_magic_and_missing_file(self, tmp_path):
-        bad = _write_model_file(str(tmp_path / "bad.bin"), b"nope")
-        assert not is_valid_whisper_cpp_model_file(bad)
-        assert not is_valid_whisper_cpp_model_file(str(tmp_path / "missing.bin"))
-        assert not is_valid_whisper_cpp_model_file("")
 
 
 class TestRegistry:

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "buzz-captions"
-version = "1.4.5"
+version = "1.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What & why

Buzz currently supports a single custom Whisper.cpp model, stored at a fixed
`ggml-model-whisper-custom.bin` path. Users who work with several fine-tuned
Whisper.cpp models can only keep one at a time.

A real example: transcribing Hebrew lectures, a fine-tuned Large-v3 **Turbo**
model is fast enough for everyday use, while a fine-tuned Large-v3 model is kept
for the occasional recording that needs higher accuracy. Both are `ggml` models;
today Buzz can only hold one as the custom model.

This PR generalises the single custom model into a small registry of custom
Whisper.cpp models, without touching the Whisper.cpp engine itself.

## Changes

- **Registry** (`buzz/settings/whisper_cpp_custom_models.py`): any number of
  custom models `{id, name, path, source_url}`, persisted in the existing
  `QSettings` store.
- **`TranscriptionModel.custom_model_id`**: resolves to a registered model's
  path. When `None`, the legacy fixed path is used.
- **Preferences UI**: lists each custom model by name; add from a local file
  (registered in place, not copied) or a download URL; delete.
- **Model selector**: custom models are listed by name and selectable
  independently.
- **Validation**: a GGML/GGUF magic-header check rejects files Whisper.cpp
  can't load (technical only — it does not judge language/quality).
- **CLI**: `--custom-model-id`.
- Tests and docs.

## Backward compatibility

- An existing `ggml-model-whisper-custom.bin` is surfaced automatically as
  "Custom Whisper.cpp Model" — not moved or re-downloaded.
- `TranscriptionModel` objects persisted by older versions (without
  `custom_model_id`) keep resolving to the legacy path.
- The Whisper.cpp engine and the language-detection plugin are unchanged;
  custom models stay excluded from automatic "largest model" selection.

## Testing

Added unit tests for validation, the registry (add/get/remove, many models,
persistence), legacy compatibility, and custom-id path resolution.